### PR TITLE
feat: configurable layout templates (Starship-style)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Configurable layout templates (Starship-style). Set `left` / `right` in
+  `config.toml` with `${name}` / `${name:variant}` placeholders to customise
+  segment order and content. Empty variables collapse adjacent literal
+  whitespace so optional segments don't leave stray spaces. New
+  `soft_wrap_cols` config (default `160`) pushes the right pane onto a
+  second line, right-aligned, when the rendered width would exceed the
+  threshold. Default behaviour unchanged when `left`/`right` are unset.
+  (#1)
+
 ## [0.1.2] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@ State per session lives at `$XDG_CACHE_HOME/cc-statusbar/<session_id>.toml`.
 A shared `recent_prs.toml` holds one GraphQL response that hydrates chip
 colors across every session.
 
+## Layout templates
+
+Customise segment order and content with Starship-style placeholders. Set
+`left` and `right` in `config.toml`; when either is set, the built-in
+hardcoded layout is replaced by your template.
+
+```toml
+left  = "${repo} ${branch}${pr_num} ${ci}${review}${comments} ${dirty}${ahead}${behind} ${ticket}"
+right = "${burn} · ${agents} · ${quotas} ${ctx} ${loc} [${model:long} · ${effort:icon}${effort:short}] ${spinner}"
+
+# When the rendered single line would exceed this width, push the right
+# pane to line 2, right-aligned to the terminal width.
+soft_wrap_cols = 160
+```
+
+Syntax:
+
+- `${name}` resolves to the variable's default form.
+- `${name:variant}` resolves to a named variant (falls back to default if
+  the variant isn't defined).
+- Empty variables collapse adjacent literal whitespace so optional segments
+  don't leave stray spaces.
+
+Variables: `repo`, `branch`, `pr_num`, `pr_icon`, `ci`, `review`,
+`comments`, `dirty`, `ahead`, `behind`, `ticket`, `burn`, `agents`,
+`quotas`, `ctx`, `loc`, `model` (`:long`, `:short`), `effort` (`:icon`,
+`:short`), `spinner`, `chips` (`:compact`, `:expanded`).
+
 ## Releasing
 
 1. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`.

--- a/config.example.toml
+++ b/config.example.toml
@@ -28,3 +28,12 @@ debug_focus_log = true
 #   "epoch-N"  – last N digits of the wall-clock epoch (e.g. "epoch-3" → "535")
 #                The 1's digit changes every second, guaranteeing visible motion.
 spinner = "compact"
+
+# Layout templates (Starship-style). Uncomment to customise segment order /
+# content. Empty variables collapse adjacent literal whitespace.
+# left  = "${repo} ${branch}${pr_num} ${ci}${review}${comments} ${dirty}${ahead}${behind} ${ticket}"
+# right = "${burn} · ${agents} · ${quotas} ${ctx} ${loc} [${model:long} · ${effort:icon}${effort:short}] ${spinner}"
+
+# When the rendered single line exceeds this width, the right pane is
+# pushed to a second line, right-aligned to the terminal width.
+# soft_wrap_cols = 160

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,15 @@ pub struct Config {
     pub debug_focus_log: Option<bool>,
     pub spinner: Option<String>,
     pub recent_prs_ttl: Option<i64>,
+    /// Layout template for the left pane. When unset, the built-in hardcoded
+    /// layout is used (existing behaviour). Syntax: `${name}` or `${name:variant}`.
+    pub left: Option<String>,
+    /// Layout template for the right pane. See `left`.
+    pub right: Option<String>,
+    /// When the rendered single line's visible width exceeds this threshold,
+    /// the right pane is pushed to a second line, right-aligned to `cols`.
+    /// Only applies when at least one of `left`/`right` is set.
+    pub soft_wrap_cols: Option<u32>,
 }
 
 impl Config {
@@ -69,6 +78,15 @@ impl Config {
     }
     pub fn spinner(&self) -> String {
         self.spinner.clone().unwrap_or_else(|| "compact".into())
+    }
+    pub fn left_template(&self) -> Option<&str> {
+        self.left.as_deref()
+    }
+    pub fn right_template(&self) -> Option<&str> {
+        self.right.as_deref()
+    }
+    pub fn soft_wrap_cols(&self) -> u32 {
+        self.soft_wrap_cols.unwrap_or(160)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod recent_prs;
 mod refresh;
 mod render;
 mod state;
+mod template;
 mod transcript;
 mod vlen;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,6 +6,7 @@ use crate::git::{CiState, GitData};
 use crate::glyphs::*;
 use crate::input::Session;
 use crate::quota::{self, WIN_5H, WIN_7D};
+use crate::template::{self, LayoutContext};
 use crate::transcript::{AgentCount, BurnInfo, OtherPrs};
 use crate::vlen;
 
@@ -18,6 +19,24 @@ pub fn build(
     tick: u64,
 ) -> String {
     let cols = effective_cols(session.cols);
+    let cfg = crate::config::config();
+
+    // If the user provided a template, build a LayoutContext and evaluate.
+    // Otherwise fall back to the existing hardcoded layout for full backwards
+    // compatibility — the existing test exercises this path.
+    if cfg.left_template().is_some() || cfg.right_template().is_some() {
+        let ctx = build_layout_context(session, git, other, burn, agents, tick);
+        let left = cfg
+            .left_template()
+            .map(|t| template::eval(t, &ctx))
+            .unwrap_or_default();
+        let right = cfg
+            .right_template()
+            .map(|t| template::eval(t, &ctx))
+            .unwrap_or_default();
+        return assemble_template(&left, &right, cols, cfg.soft_wrap_cols());
+    }
+
     let mut left = build_left(session, git, other);
     let right = build_right(session, burn, agents, tick);
     let chip_compact = build_chip_compact(other, &git.pr.url);
@@ -546,6 +565,365 @@ mod tests {
             );
         }
     }
+
+    /// When the rendered single-line width would exceed `soft_wrap_cols`, the
+    /// right pane is pushed to a second line, right-aligned to `cols`.
+    #[test]
+    fn assemble_template_soft_wraps_when_too_wide() {
+        unsafe {
+            std::env::set_var("CC_STATUSLINE_NF_WIDTH", "1");
+        }
+        // Plain ASCII left/right; lengths sum well past soft_wrap_cols.
+        let left = "L".repeat(100);
+        let right = "R".repeat(100);
+        let cols = 200u32;
+        let soft_wrap_cols = 160u32;
+        let out = assemble_template(&left, &right, cols, soft_wrap_cols);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2, "expected 2 lines, got {out:?}");
+        assert_eq!(lines[0], left, "line 1 should be left pane only");
+        let line2 = lines[1];
+        assert!(!line2.is_empty(), "line 2 should be non-empty");
+        // Right-aligned to `cols`: total visible width == cols, ends with right.
+        let line2_width = vlen::vlen(line2);
+        assert_eq!(line2_width, cols, "line 2 width = cols");
+        assert!(
+            line2.ends_with(&right),
+            "line 2 should end with right pane ({line2:?})"
+        );
+    }
+}
+
+/// Right-align `left` and `right` to `cols` cells. If the combined width
+/// exceeds `soft_wrap_cols`, push `right` to a second line, right-aligned to
+/// `cols`. If left+gap+right doesn't fit on one line, truncate left (same
+/// strategy as the legacy assemble path).
+fn assemble_template(left: &str, right: &str, cols: u32, soft_wrap_cols: u32) -> String {
+    let llen = vlen::vlen(left);
+    let rlen = vlen::vlen(right);
+    let gap: u32 = 2;
+    let total = llen + rlen + gap;
+
+    // Soft-wrap: rendered single line would exceed `soft_wrap_cols`. Push the
+    // entire right pane to a second line, right-aligned to `cols`.
+    if soft_wrap_cols > 0 && total > soft_wrap_cols {
+        let mut out = String::new();
+        if left.is_empty() {
+            let pad_n = cols.saturating_sub(rlen) as usize;
+            out.push_str(&" ".repeat(pad_n));
+            out.push_str(right);
+        } else {
+            out.push_str(left);
+            if !right.is_empty() {
+                out.push('\n');
+                let pad_n = cols.saturating_sub(rlen) as usize;
+                out.push_str(&" ".repeat(pad_n));
+                out.push_str(right);
+            }
+        }
+        return out;
+    }
+
+    let mut out = String::new();
+    if left.is_empty() && right.is_empty() {
+        return out;
+    } else if left.is_empty() {
+        let pad_n = (cols.saturating_sub(rlen + 1)).max(1) as usize;
+        out.push_str(&format!("{DIM}·{RESET}{}{right}", " ".repeat(pad_n)));
+    } else if right.is_empty() {
+        out.push_str(left);
+    } else if total <= cols {
+        let pad_n = cols.saturating_sub(llen + rlen).max(gap) as usize;
+        out.push_str(&format!("{left}{}{right}", " ".repeat(pad_n)));
+    } else {
+        let budget = cols.saturating_sub(rlen + gap + 1);
+        let stripped = vlen::strip(left);
+        let truncated = vlen::truncate_to_width(&stripped, budget);
+        let left_out = format!("{truncated}{DIM}…{RESET}");
+        let llen2 = vlen::vlen(&left_out);
+        let pad_n = cols.saturating_sub(llen2 + rlen).max(gap) as usize;
+        out.push_str(&format!("{left_out}{}{right}", " ".repeat(pad_n)));
+    }
+    out
+}
+
+/// Build a `LayoutContext` populated with all supported variables (and
+/// variants) for the given session/git/transcript snapshot. Each value is a
+/// pre-rendered string, possibly empty (which makes adjacent template
+/// whitespace collapse).
+fn build_layout_context(
+    session: &Session,
+    git: &GitData,
+    other: &OtherPrs,
+    burn: &BurnInfo,
+    agents: &AgentCount,
+    tick: u64,
+) -> LayoutContext {
+    let mut c = LayoutContext::new();
+
+    // ── repo / location ─────────────────────────────────────────────────
+    let loc_disp = compute_loc_disp(session, git);
+    c.set(
+        "repo",
+        if loc_disp.is_empty() {
+            String::new()
+        } else {
+            format!("{DIM}{loc_disp}{RESET}")
+        },
+    );
+
+    // ── PR icon + state-colored ─────────────────────────────────────────
+    let (icon_glyph, state_color) = match git.pr.state.as_str() {
+        "MERGED" => (MERGED, FG_GH_MERGED),
+        "CLOSED" => (PR_CLOSED, FG_GH_CLOSED),
+        "OPEN" if git.pr.is_draft => (PR_DRAFT, FG_GH_DRAFT),
+        "OPEN" => (PR_OPEN, FG_GH_OPEN),
+        _ => (BRANCH, DIM),
+    };
+    c.set(
+        "pr_icon",
+        if git.branch.is_empty() {
+            String::new()
+        } else {
+            format!("{state_color}{icon_glyph}{RESET}")
+        },
+    );
+
+    // ── branch (linked to PR url when available) ────────────────────────
+    if git.branch.is_empty() {
+        c.set("branch", "");
+        c.set("pr_num", "");
+    } else {
+        let label_plain = git.branch.clone();
+        let branch_str = if !git.pr.url.is_empty() {
+            link(&git.pr.url, &label_plain)
+        } else {
+            label_plain
+        };
+        c.set("branch", branch_str);
+        c.set(
+            "pr_num",
+            git.pr
+                .number
+                .map(|n| format!(" {state_color}#{n}{RESET}"))
+                .unwrap_or_default(),
+        );
+    }
+
+    // ── ci ──────────────────────────────────────────────────────────────
+    let ci_raw = match git.ci_state() {
+        CiState::Pass => format!("{FG_GREEN}{CI_PASS}{RESET}"),
+        CiState::Fail => format!("{FG_RED}{CI_FAIL}{RESET}"),
+        CiState::Pend => format!("{FG_YELLOW}{CI_PEND}{RESET}"),
+        CiState::None => String::new(),
+    };
+    let ci_out = if !ci_raw.is_empty() && !git.pr.url.is_empty() {
+        link(&format!("{}/checks", git.pr.url), &ci_raw)
+    } else {
+        ci_raw
+    };
+    c.set("ci", ci_out);
+
+    // ── review ──────────────────────────────────────────────────────────
+    c.set(
+        "review",
+        match git.pr.review_decision.as_str() {
+            "APPROVED" => format!("{FG_GREEN}{APPROVED}{RESET}"),
+            "CHANGES_REQUESTED" => format!("{FG_RED}{CHANGES}{RESET}"),
+            _ => String::new(),
+        },
+    );
+
+    // ── comments ────────────────────────────────────────────────────────
+    let comments_n = git.pr.comments.len();
+    c.set(
+        "comments",
+        if comments_n > 0 {
+            format!("{COMMENT}{comments_n}")
+        } else {
+            String::new()
+        },
+    );
+
+    // ── dirty / ahead / behind ──────────────────────────────────────────
+    c.set(
+        "dirty",
+        if git.dirty > 0 {
+            format!("{FG_YELLOW}{DIRTY}{}{RESET}", git.dirty)
+        } else {
+            String::new()
+        },
+    );
+    c.set(
+        "ahead",
+        if git.ahead > 0 {
+            format!("{DIM}{AHEAD}{}{RESET}", git.ahead)
+        } else {
+            String::new()
+        },
+    );
+    c.set(
+        "behind",
+        if git.behind > 0 {
+            format!("{FG_YELLOW}{BEHIND}{}{RESET}", git.behind)
+        } else {
+            String::new()
+        },
+    );
+
+    // ── linear ticket ───────────────────────────────────────────────────
+    c.set(
+        "ticket",
+        if let Some(t) = crate::git::extract_ticket(&git.branch) {
+            let url = crate::git::linear_url(&t);
+            let label = format!("[{t}]");
+            format!("{FG_CYAN}{}{RESET}", link(&url, &label))
+        } else {
+            String::new()
+        },
+    );
+
+    // ── burn rate ───────────────────────────────────────────────────────
+    let burn_str = if burn.tokens_per_hour > 0 {
+        let n = burn.tokens_per_hour;
+        let human = if n >= 1_000_000 {
+            format!("{:.1}M", n as f64 / 1_000_000.0)
+        } else if n >= 1_000 {
+            format!("{}k", (n as f64 / 1_000.0).round() as u64)
+        } else {
+            format!("{n}")
+        };
+        format!("{DIM}Σ{RESET} {human}{DIM}/hr{RESET}")
+    } else {
+        String::new()
+    };
+    c.set("burn", burn_str);
+
+    // ── agents ──────────────────────────────────────────────────────────
+    let agent_str = if agents.total > 0 {
+        if agents.active > 0 {
+            format!(
+                "{FG_YELLOW}{AGENT}{RESET} {}{DIM}/{}{RESET}",
+                agents.active, agents.total
+            )
+        } else {
+            format!("{DIM}{AGENT} {}{RESET}", agents.total)
+        }
+    } else {
+        String::new()
+    };
+    c.set("agents", agent_str);
+
+    // ── quotas ──────────────────────────────────────────────────────────
+    let q5h = quota::fmt_quota(session.r5h, session.r5h_reset, WIN_5H, CLOCK_5H);
+    let q7d = quota::fmt_quota(session.r7d, session.r7d_reset, WIN_7D, CALENDAR_7D);
+    let mut quota_str = String::new();
+    if !q5h.is_empty() {
+        quota_str.push_str(&q5h);
+    }
+    if !q7d.is_empty() {
+        if !quota_str.is_empty() {
+            quota_str.push_str(&format!(" {DIM}·{RESET} "));
+        }
+        quota_str.push_str(&q7d);
+    }
+    c.set("quotas", quota_str);
+
+    // ── ctx bar + pct ───────────────────────────────────────────────────
+    let bar = build_bar(session.ctx_pct);
+    c.set(
+        "ctx",
+        format!("{DIM}{CTX}{RESET} {bar} {}%", session.ctx_pct),
+    );
+
+    // ── location icon ───────────────────────────────────────────────────
+    c.set("loc", location_icon());
+
+    // ── model (with variants) ───────────────────────────────────────────
+    let model_long = format!("{BOLD}{}{RESET}", session.model);
+    let model_short_label: String = session.model.chars().take(6).collect();
+    let model_short = format!("{BOLD}{model_short_label}{RESET}");
+    c.set("model", model_long.clone());
+    c.set_variant("model", "long", model_long);
+    c.set_variant("model", "short", model_short);
+
+    // ── effort (with variants) ──────────────────────────────────────────
+    let (effort_color, effort_label) = match session.effort.as_str() {
+        "high" => (FG_RED, "L"),
+        "medium" => (FG_YELLOW, "M"),
+        "low" => (FG_GREEN, "S"),
+        "minimal" => (FG_GREEN, "XS"),
+        "" => (DIM, ""),
+        other => (DIM, other),
+    };
+    if effort_label.is_empty() {
+        c.set("effort", "");
+        c.set_variant("effort", "icon", "");
+        c.set_variant("effort", "short", "");
+    } else {
+        c.set(
+            "effort",
+            format!("{effort_color}{EFFORT} {effort_label}{RESET}"),
+        );
+        c.set_variant("effort", "icon", format!("{effort_color}{EFFORT}{RESET}"));
+        c.set_variant(
+            "effort",
+            "short",
+            format!("{effort_color}{effort_label}{RESET}"),
+        );
+    }
+
+    // ── spinner ─────────────────────────────────────────────────────────
+    c.set("spinner", format!("{DIM}{}{RESET}", spinner_text(tick)));
+
+    // ── chips (other PRs) ───────────────────────────────────────────────
+    let chip_compact = build_chip_compact(other, &git.pr.url);
+    let chip_expanded = build_chip_expanded(other, &git.pr.url);
+    c.set("chips", chip_compact.clone());
+    c.set_variant("chips", "compact", chip_compact);
+    c.set_variant("chips", "expanded", chip_expanded);
+
+    c
+}
+
+fn compute_loc_disp(session: &Session, git: &GitData) -> String {
+    let mut loc_disp = String::new();
+    if !git.origin_url.is_empty() {
+        loc_disp = pretty_repo(&git.origin_url);
+        if let (Some(gd), Some(cd), Some(top)) = (&git.git_dir, &git.common_dir, &git.toplevel) {
+            if let (Ok(g_abs), Ok(c_abs)) = (gd.canonicalize(), cd.canonicalize()) {
+                if g_abs != c_abs {
+                    let wt_name = top
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    if !wt_name.is_empty() && wt_name != git.branch {
+                        loc_disp.push_str(&format!(
+                            " {FG_CYAN}{WORKTREE}{RESET}{DIM} {wt_name}{RESET}"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    if loc_disp.is_empty() {
+        let cwd = if !session.cwd.is_empty() {
+            session.cwd.clone()
+        } else {
+            std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        };
+        let home = std::env::var("HOME").unwrap_or_default();
+        loc_disp = if !home.is_empty() && cwd == home {
+            "~".into()
+        } else if !home.is_empty() && cwd.starts_with(&format!("{home}/")) {
+            format!("~{}", &cwd[home.len()..])
+        } else {
+            cwd
+        };
+    }
+    loc_disp
 }
 
 fn spinner_text(tick: u64) -> String {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,0 +1,289 @@
+// Layout template DSL — Starship-inspired `${name}` / `${name:variant}`
+// substitution over a `LayoutContext` of pre-rendered segment strings.
+//
+// Empty segments collapse adjacent literal whitespace so a template like
+// `"${a} ${b}"` with `b == ""` renders as `"a"` instead of `"a "`.
+
+use std::collections::HashMap;
+
+/// All segment values are strings (which may embed ANSI escapes / OSC 8
+/// hyperlinks). Resolution is a pure lookup — no I/O at evaluation time.
+#[derive(Debug, Default, Clone)]
+pub struct LayoutContext {
+    /// Map from `(name, variant)` → pre-rendered string. Variant `""` is the
+    /// default form. An entry whose value is empty is treated as a soft empty
+    /// (collapses whitespace); a missing entry behaves the same.
+    pub vars: HashMap<(String, String), String>,
+}
+
+impl LayoutContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert the default form of a variable.
+    pub fn set(&mut self, name: &str, value: impl Into<String>) {
+        self.vars.insert((name.into(), String::new()), value.into());
+    }
+
+    /// Insert a named variant of a variable (e.g. `model:long`).
+    pub fn set_variant(&mut self, name: &str, variant: &str, value: impl Into<String>) {
+        self.vars
+            .insert((name.into(), variant.into()), value.into());
+    }
+
+    fn lookup(&self, name: &str, variant: &str) -> Option<&str> {
+        self.vars
+            .get(&(name.to_string(), variant.to_string()))
+            .map(|s| s.as_str())
+            .or_else(|| {
+                if !variant.is_empty() {
+                    // Fall back to default form if variant not provided.
+                    self.vars
+                        .get(&(name.to_string(), String::new()))
+                        .map(|s| s.as_str())
+                } else {
+                    None
+                }
+            })
+    }
+}
+
+/// Parsed token in a template string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Token {
+    Literal(String),
+    Var { name: String, variant: String },
+}
+
+/// Parse `${name}` and `${name:variant}` placeholders. Unknown / malformed
+/// forms are emitted as literals (best-effort, never panics).
+fn parse(template: &str) -> Vec<Token> {
+    let bytes = template.as_bytes();
+    let mut out = Vec::new();
+    let mut buf = String::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
+            if let Some(end) = template[i + 2..].find('}') {
+                let inner = &template[i + 2..i + 2 + end];
+                let (name, variant) = match inner.split_once(':') {
+                    Some((n, v)) => (n.trim().to_string(), v.trim().to_string()),
+                    None => (inner.trim().to_string(), String::new()),
+                };
+                if !name.is_empty() {
+                    if !buf.is_empty() {
+                        out.push(Token::Literal(std::mem::take(&mut buf)));
+                    }
+                    out.push(Token::Var { name, variant });
+                    i += 2 + end + 1;
+                    continue;
+                }
+            }
+        }
+        // Push the byte we couldn't interpret as a placeholder. UTF-8 safe:
+        // step by char rather than byte.
+        let ch = template[i..].chars().next().unwrap();
+        buf.push(ch);
+        i += ch.len_utf8();
+    }
+    if !buf.is_empty() {
+        out.push(Token::Literal(buf));
+    }
+    out
+}
+
+/// Evaluate `template` against `ctx`. Empty variable values cause adjacent
+/// literal whitespace to collapse: a sequence `<ws>${empty}<ws>` between two
+/// non-empty segments collapses to a single space; at the start or end of
+/// the output it collapses to nothing.
+pub fn eval(template: &str, ctx: &LayoutContext) -> String {
+    let tokens = parse(template);
+    // Two-pass approach. Pass 1 builds a flat sequence of "atoms":
+    //   - Content(s)  → resolved variable or literal non-whitespace run
+    //   - Ws(s)       → literal whitespace run (kept as-is, e.g. "  " or " · "
+    //                    no — mixed runs are Content)
+    //   - EmptyVar    → variable that resolved to empty / missing
+    // Pass 2 collapses `Ws* EmptyVar Ws*` runs.
+    enum Atom {
+        Content(String),
+        Ws(String),
+        Empty,
+    }
+    let mut atoms: Vec<Atom> = Vec::new();
+    for t in tokens {
+        match t {
+            Token::Literal(s) => {
+                // Split literal into alternating ws / non-ws runs so we can
+                // collapse whitespace adjacent to empty vars without losing
+                // non-whitespace content.
+                let mut cur = String::new();
+                let mut cur_is_ws = true;
+                let mut started = false;
+                for ch in s.chars() {
+                    let is_ws = ch == ' ' || ch == '\t';
+                    if !started {
+                        cur_is_ws = is_ws;
+                        started = true;
+                    }
+                    if is_ws == cur_is_ws {
+                        cur.push(ch);
+                    } else {
+                        if !cur.is_empty() {
+                            atoms.push(if cur_is_ws {
+                                Atom::Ws(std::mem::take(&mut cur))
+                            } else {
+                                Atom::Content(std::mem::take(&mut cur))
+                            });
+                        }
+                        cur_is_ws = is_ws;
+                        cur.push(ch);
+                    }
+                }
+                if started && !cur.is_empty() {
+                    atoms.push(if cur_is_ws {
+                        Atom::Ws(cur)
+                    } else {
+                        Atom::Content(cur)
+                    });
+                }
+            }
+            Token::Var { name, variant } => {
+                match ctx.lookup(&name, &variant).filter(|s| !s.is_empty()) {
+                    Some(v) => atoms.push(Atom::Content(v.to_string())),
+                    None => atoms.push(Atom::Empty),
+                }
+            }
+        }
+    }
+
+    // Collapse: locate each Empty and remove all adjacent Ws runs on both
+    // sides. If Content exists on both sides after collapse, insert a single
+    // " " in place. If at start/end, insert nothing.
+    // Simpler: process linearly emitting to a new vec, tracking whether we
+    // "owe" a space due to a collapsed empty between content.
+    let mut out_atoms: Vec<Atom> = Vec::new();
+    let mut i = 0;
+    while i < atoms.len() {
+        match &atoms[i] {
+            Atom::Empty => {
+                // Drop trailing Ws atoms already in out_atoms.
+                while matches!(out_atoms.last(), Some(Atom::Ws(_))) {
+                    out_atoms.pop();
+                }
+                // Skip following Ws atoms.
+                let mut j = i + 1;
+                while matches!(atoms.get(j), Some(Atom::Ws(_))) {
+                    j += 1;
+                }
+                // If both sides had Content, leave a single space placeholder.
+                let left_has_content = matches!(out_atoms.last(), Some(Atom::Content(_)));
+                let right_has_content = matches!(atoms.get(j), Some(Atom::Content(_)));
+                if left_has_content && right_has_content {
+                    out_atoms.push(Atom::Ws(" ".to_string()));
+                }
+                i = j;
+            }
+            _ => {
+                // Move atom (clone since we still iterate by ref).
+                out_atoms.push(match &atoms[i] {
+                    Atom::Content(s) => Atom::Content(s.clone()),
+                    Atom::Ws(s) => Atom::Ws(s.clone()),
+                    Atom::Empty => unreachable!(),
+                });
+                i += 1;
+            }
+        }
+    }
+    // Strip leading/trailing whitespace atoms.
+    while matches!(out_atoms.first(), Some(Atom::Ws(_))) {
+        out_atoms.remove(0);
+    }
+    while matches!(out_atoms.last(), Some(Atom::Ws(_))) {
+        out_atoms.pop();
+    }
+
+    let mut out = String::new();
+    for a in out_atoms {
+        match a {
+            Atom::Content(s) | Atom::Ws(s) => out.push_str(&s),
+            Atom::Empty => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_from(pairs: &[(&str, &str)]) -> LayoutContext {
+        let mut c = LayoutContext::new();
+        for (k, v) in pairs {
+            if let Some((n, var)) = k.split_once(':') {
+                c.set_variant(n, var, *v);
+            } else {
+                c.set(k, *v);
+            }
+        }
+        c
+    }
+
+    #[test]
+    fn template_substitutes_variables() {
+        let ctx = ctx_from(&[
+            ("repo", "foo/bar"),
+            ("branch", "main"),
+            ("model:long", "Claude Opus 4.7"),
+            ("effort:icon", "⚡"),
+            ("effort:short", "M"),
+        ]);
+        let s = eval(
+            "${repo} ${branch} [${model:long} ${effort:icon}${effort:short}]",
+            &ctx,
+        );
+        assert_eq!(s, "foo/bar main [Claude Opus 4.7 ⚡M]");
+    }
+
+    #[test]
+    fn template_collapses_empty_segments() {
+        let ctx = ctx_from(&[("a", "a"), ("b", "")]);
+        // Trailing empty: "${a} ${b}" → "a"
+        assert_eq!(eval("${a} ${b}", &ctx), "a");
+        // Middle empty: "${a} ${b} ${a}" → "a a" (single space, not "a  a")
+        let mut ctx2 = ctx.clone();
+        ctx2.set("c", "c");
+        assert_eq!(eval("${a} ${b} ${c}", &ctx2), "a c");
+        // Leading empty: "${b} ${a}" → "a"
+        assert_eq!(eval("${b} ${a}", &ctx), "a");
+    }
+
+    #[test]
+    fn template_unknown_variable_treated_as_empty() {
+        let ctx = ctx_from(&[("a", "a")]);
+        assert_eq!(eval("${a} ${nope}", &ctx), "a");
+        assert_eq!(eval("${nope} ${a}", &ctx), "a");
+    }
+
+    #[test]
+    fn template_variant_falls_back_to_default() {
+        let ctx = ctx_from(&[("model", "Opus")]);
+        assert_eq!(eval("${model:long}", &ctx), "Opus");
+    }
+
+    #[test]
+    fn template_preserves_literal_punctuation() {
+        let ctx = ctx_from(&[("a", "x"), ("b", "y")]);
+        assert_eq!(eval("${a} · ${b}", &ctx), "x · y");
+        // When b is empty the " · " separator collapses too.
+        let ctx2 = ctx_from(&[("a", "x"), ("b", "")]);
+        assert_eq!(eval("${a} · ${b}", &ctx2), "x ·");
+    }
+
+    #[test]
+    fn template_malformed_passes_through() {
+        let ctx = ctx_from(&[("a", "x")]);
+        assert_eq!(eval("$ {a} ${a}", &ctx), "$ {a} x");
+        assert_eq!(eval("${unclosed", &ctx), "${unclosed");
+    }
+}


### PR DESCRIPTION
Closes #1

## Summary

Replaces the hardcoded statusline layout with a config-driven template DSL similar to [Starship](https://starship.rs/). When `left` / `right` are set in `config.toml`, the renderer evaluates them against a `LayoutContext` of pre-rendered segment strings; otherwise the existing hardcoded layout runs unchanged.

```toml
left  = "${repo} ${branch}${pr_num} ${ci}${review}${comments} ${dirty}${ahead}${behind} ${ticket}"
right = "${burn} · ${agents} · ${quotas} ${ctx} ${loc} [${model:long} · ${effort:icon}${effort:short}] ${spinner}"
soft_wrap_cols = 160
```

- New `src/template.rs` module: `${name}` / `${name:variant}` parser + evaluator. Empty variables collapse adjacent literal whitespace so `"${a} ${b}"` with `b == ""` renders as `"a"`.
- `render::build_layout_context` populates every supported variable (and variant) once per render — no I/O during template evaluation.
- New `soft_wrap_cols` (default `160`) pushes the right pane onto a second line, right-aligned to `cols`, when the rendered single line would exceed the threshold.
- Default behaviour preserved: when `left`/`right` aren't set, the existing `build_left` / `build_right` / chip-line2 fallback runs untouched, so `render_fills_cols_exactly` continues to pass.

## Variables supported

`repo`, `branch`, `pr_num`, `pr_icon`, `ci`, `review`, `comments`, `dirty`, `ahead`, `behind`, `ticket`, `burn`, `agents`, `quotas`, `ctx`, `loc`, `model` (`:long`, `:short`), `effort` (`:icon`, `:short`), `spinner`, `chips` (`:compact`, `:expanded`).

## Notes / decisions

- Soft-wrap only applies when at least one of `left` / `right` is set, so existing users see no change at all (the legacy chip-line2 fallback continues to handle "other PRs" overflow for the default layout).
- `${model:short}` truncates to 6 characters as a reasonable default; users can build their own short forms via the variant syntax later.
- An unknown variant falls back to the variable's default form (closer to user intent than rendering nothing).

## Test plan

- [x] `cargo test --release` (10/10 passing, including new `template_substitutes_variables`, `template_collapses_empty_segments`, `assemble_template_soft_wraps_when_too_wide`)
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual smoke test in a real shell with a custom `left`/`right` template

🤖 Generated with [Claude Code](https://claude.com/claude-code)