### PR TITLE
feat: render Graphite stacks in stack order (Closes #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-04-29
+
 ### Added
 
+- Render Graphite stacks in stack order in the chips component. When `gt` is
+  on `$PATH` and `gt log --json` succeeds in `$CWD`, chips are reordered
+  trunk → leaf, joined with a configurable separator (default `─•─`), and
+  prefixed by a configurable leading glyph (default the Nerd Font branch
+  glyph, dim cyan). PRs not reachable from the worktree's trunk are appended
+  after the stacked chain, sorted by ascending PR number — identical to the
+  legacy ordering — so non-stack workflows are unaffected. Detection runs
+  on the same detached `--refresh-*` path used for PR/other refreshes; the
+  foreground render never blocks on `gt`. Cached in the per-session state
+  TOML with a configurable TTL (`[chips].stack_refresh_ttl`, default 60s)
+  and a separate `locked_at` debounce to prevent thundering-herd `gt`
+  invocations. New `[chips]` config keys: `stack_separator`, `stack_glyph`
+  (set `""` to disable), `force_stack` (treat all sessions as gt-stacks),
+  `stack_refresh_ttl`. (#2, closes #2)
 - Composable component model. Every statusline element now implements a
   `Component` trait with declared size variants (`xs`/`s`/`m`/`l`/`xl`)
   and per-component config (`priority`, `min`, `sizes`, `required`). New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "cc-statusline"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-statusline"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.89"
 description = "Claude Code statusline — Rust port of the bash original"

--- a/config.example.toml
+++ b/config.example.toml
@@ -80,6 +80,18 @@ empty    = "░"
 
 [chips]
 priority = 5
+# Graphite stack rendering. When `gt log --json` succeeds in $CWD and at least
+# two of the session's discovered PRs map to branches in the stack, chips are
+# reordered trunk → leaf and joined with `stack_separator`, prefixed by
+# `stack_glyph` rendered in dim cyan. PRs not reachable from trunk are
+# appended after the stacked chain, sorted by ascending PR number.
+#
+# stack_glyph = ""        # disable the leading marker
+# force_stack = true      # use stack layout even when `gt` is absent
+stack_separator   = "─•─"
+stack_glyph       = ""   # nf-oct-git_branch
+force_stack       = false
+stack_refresh_ttl = 60
 
 [model]
 priority = 80

--- a/src/components.rs
+++ b/src/components.rs
@@ -396,6 +396,38 @@ impl Component for Ticket {
 
 // ─── chips (other PRs) ──────────────────────────────────────────────────
 
+/// `[chips]` config block. Common ComponentConfig fields (priority/min/sizes/
+/// required/default) live alongside chips-specific stack-mode knobs.
+///
+/// In stack mode (Graphite detected and ≥2 chip PRs covered by the stack),
+/// chips are reordered by depth and joined with `stack_separator`, prefixed
+/// by `stack_glyph` in dim cyan. Set `force_stack=true` to use the stack
+/// layout even without `gt`; set `stack_glyph=""` to suppress the leading
+/// glyph.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ChipsConfig {
+    pub stack_separator: String,
+    pub stack_glyph: String,
+    pub force_stack: bool,
+    pub stack_refresh_ttl: i64,
+    #[serde(flatten)]
+    pub common: crate::component::ComponentConfig,
+}
+
+impl Default for ChipsConfig {
+    fn default() -> Self {
+        Self {
+            stack_separator: "─•─".into(),
+            // Default to the Nerd Font branch glyph; users can clear via "".
+            stack_glyph: BRANCH.into(),
+            force_stack: false,
+            stack_refresh_ttl: 60,
+            common: crate::component::ComponentConfig::default(),
+        }
+    }
+}
+
 pub struct Chips;
 
 fn pr_color_for(other: &crate::transcript::OtherPrs, url: &str) -> &'static str {
@@ -416,8 +448,76 @@ fn chip_should_render(other: &crate::transcript::OtherPrs, current_url: &str) ->
     false
 }
 
+fn pr_num_from_url(url: &str) -> Option<u32> {
+    let rest = url.strip_prefix("https://github.com/")?;
+    let (_, num_part) = rest.split_once("/pull/")?;
+    num_part.split(['/', '?', '#']).next()?.parse().ok()
+}
+
+/// Order URLs for stack-mode rendering. Stack-covered PRs come first in
+/// trunk→leaf depth order; the rest are appended sorted by ascending PR
+/// number. Returns `None` when stack mode does not apply (no gt, or fewer
+/// than 2 chip URLs are covered by the stack and force_stack is false).
+fn stack_ordered_urls(
+    other: &crate::transcript::OtherPrs,
+    force_stack: bool,
+) -> Option<Vec<String>> {
+    if !other.is_gt && !force_stack {
+        return None;
+    }
+    // PR number → URL for the chip set. Multiple URLs with the same PR number
+    // are unlikely (cross-repo filtering already happened upstream).
+    let mut by_num: std::collections::HashMap<u32, String> = std::collections::HashMap::new();
+    let mut leftover: Vec<String> = Vec::new();
+    for u in &other.urls {
+        match pr_num_from_url(u) {
+            Some(n) => {
+                by_num.insert(n, u.clone());
+            }
+            None => leftover.push(u.clone()),
+        }
+    }
+    // Walk stack entries in depth order, picking up matching chips.
+    let mut stacked_urls: Vec<String> = Vec::new();
+    let mut sorted_entries: Vec<&crate::transcript::StackChipEntry> =
+        other.stack_entries.iter().collect();
+    sorted_entries.sort_by_key(|e| e.depth);
+    let mut consumed: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    for e in sorted_entries {
+        if let Some(pr) = e.pr {
+            if let Some(u) = by_num.get(&pr) {
+                stacked_urls.push(u.clone());
+                consumed.insert(pr);
+            }
+        }
+    }
+    // Require ≥2 covered chips for stack mode (unless forced) — a single
+    // matched chip is no improvement over the legacy ordering.
+    if !force_stack && stacked_urls.len() < 2 {
+        return None;
+    }
+    // Append uncovered chips, sorted by PR number ascending (legacy fallback).
+    let mut rest_pairs: Vec<(u32, String)> = by_num
+        .into_iter()
+        .filter(|(n, _)| !consumed.contains(n))
+        .collect();
+    rest_pairs.sort_by_key(|(n, _)| *n);
+    let mut out = stacked_urls;
+    for (_, u) in rest_pairs {
+        out.push(u);
+    }
+    out.extend(leftover);
+    Some(out)
+}
+
+fn render_chip(other: &crate::transcript::OtherPrs, url: &str) -> String {
+    let n = url.rsplit('/').next().unwrap_or("");
+    let c = pr_color_for(other, url);
+    link(url, &format!("{c}#{n}{RESET}"))
+}
+
 impl Component for Chips {
-    type Config = ();
+    type Config = ChipsConfig;
     fn name() -> &'static str {
         "chips"
     }
@@ -427,28 +527,47 @@ impl Component for Chips {
     fn default_size() -> Size {
         Size::Xl
     }
-    fn render(&self, size: Size, _cfg: &(), ctx: &RenderCtx) -> Rendered {
+    fn render(&self, size: Size, cfg: &ChipsConfig, ctx: &RenderCtx) -> Rendered {
         if size == Size::Xs {
             return Rendered::empty();
         }
         if !chip_should_render(ctx.other, &ctx.git.pr.url) {
             return Rendered::empty();
         }
+
+        let stack = stack_ordered_urls(ctx.other, cfg.force_stack);
+
         match size {
             Size::S | Size::M => {
+                // Compact: still ×N count even in stack mode (Xs already
+                // dropped earlier; Sm+ shows the chain, but only at L+ here
+                // because the fixed sizes() list is Xs/S/M/Xl).
                 let n = ctx.other.urls.len();
                 Rendered::from_text(format!("{DIM}{PR_OPEN}×{n}{RESET}"))
             }
-            _ => {
-                let mut parts = String::new();
-                for u in &ctx.other.urls {
-                    let n = u.rsplit('/').next().unwrap_or("");
-                    let c = pr_color_for(ctx.other, u);
-                    parts.push(' ');
-                    parts.push_str(&link(u, &format!("{c}#{n}{RESET}")));
+            _ => match stack {
+                Some(urls) if !urls.is_empty() => {
+                    let sep = format!("{DIM}{}{RESET}", cfg.stack_separator);
+                    let glyph = if cfg.stack_glyph.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{DIM}{FG_CYAN}{}{RESET} ", cfg.stack_glyph)
+                    };
+                    let chips: Vec<String> =
+                        urls.iter().map(|u| render_chip(ctx.other, u)).collect();
+                    Rendered::from_text(format!("{glyph}{}", chips.join(&sep)))
                 }
-                Rendered::from_text(format!("{DIM}{PR_OPEN}{RESET}{parts}"))
-            }
+                _ => {
+                    // Legacy path: leading PR_OPEN icon, space-separated chips
+                    // in their original (transcript-discovered) order.
+                    let mut parts = String::new();
+                    for u in &ctx.other.urls {
+                        parts.push(' ');
+                        parts.push_str(&render_chip(ctx.other, u));
+                    }
+                    Rendered::from_text(format!("{DIM}{PR_OPEN}{RESET}{parts}"))
+                }
+            },
         }
     }
 }
@@ -813,7 +932,7 @@ pub fn render_named(name: &str, size: Size, ctx: &RenderCtx) -> Option<Rendered>
         "ahead" => Ahead.render(size, &(), ctx),
         "behind" => Behind.render(size, &(), ctx),
         "ticket" => Ticket.render(size, &(), ctx),
-        "chips" => Chips.render(size, &(), ctx),
+        "chips" => Chips.render(size, &cfg.chips, ctx),
         "burn" => Burn.render(size, &(), ctx),
         "agents" => Agents.render(size, &(), ctx),
         "quotas" => Quotas.render(size, &(), ctx),
@@ -981,5 +1100,163 @@ mod tests {
         let xs = bar.render(Size::Xs, &cfg, &ctx).width;
         let xl = bar.render(Size::Xl, &cfg, &ctx).width;
         assert!(xl > xs);
+    }
+
+    fn url(n: u32) -> String {
+        format!("https://github.com/foo/bar/pull/{n}")
+    }
+
+    fn entry(branch: &str, pr: Option<u32>, depth: u32) -> crate::transcript::StackChipEntry {
+        crate::transcript::StackChipEntry {
+            branch: branch.into(),
+            pr,
+            depth,
+        }
+    }
+
+    fn stack_other(urls: Vec<u32>, entries: Vec<crate::transcript::StackChipEntry>) -> OtherPrs {
+        OtherPrs {
+            urls: urls.into_iter().map(url).collect(),
+            states: Default::default(),
+            is_gt: true,
+            stack_entries: entries,
+        }
+    }
+
+    #[test]
+    fn chips_stack_orders_by_depth() {
+        // Stack: trunk(main, depth 0, no PR) → feat/a(#101, depth 1)
+        //                                    → feat/b(#102, depth 2)
+        //                                    → feat/c(#103, depth 3)
+        // Discovered URLs are scrambled (#103, #101, #102) — output must be
+        // trunk-first depth ordering.
+        let other = stack_other(
+            vec![103, 101, 102],
+            vec![
+                entry("main", None, 0),
+                entry("feat/a", Some(101), 1),
+                entry("feat/b", Some(102), 2),
+                entry("feat/c", Some(103), 3),
+            ],
+        );
+        let cfg = ChipsConfig::default();
+        let ordered = stack_ordered_urls(&other, cfg.force_stack).expect("stack mode active");
+        assert_eq!(
+            ordered,
+            vec![url(101), url(102), url(103)],
+            "depth-ordered chip URLs"
+        );
+    }
+
+    #[test]
+    fn chips_uncovered_prs_appended_after_stack() {
+        // #999 is not in the stack — must come after all stacked chips,
+        // sorted ascending among the uncovered set.
+        let other = stack_other(
+            vec![102, 999, 101],
+            vec![entry("feat/a", Some(101), 1), entry("feat/b", Some(102), 2)],
+        );
+        let cfg = ChipsConfig::default();
+        let ordered = stack_ordered_urls(&other, cfg.force_stack).expect("stack active");
+        assert_eq!(ordered, vec![url(101), url(102), url(999)]);
+    }
+
+    #[test]
+    fn chips_fallback_when_not_gt() {
+        // is_gt=false, force_stack=false ⇒ no stack ordering.
+        let mut other = stack_other(
+            vec![102, 101],
+            vec![entry("feat/a", Some(101), 1), entry("feat/b", Some(102), 2)],
+        );
+        other.is_gt = false;
+        let cfg = ChipsConfig::default();
+        assert!(stack_ordered_urls(&other, cfg.force_stack).is_none());
+    }
+
+    #[test]
+    fn chips_requires_two_covered_for_stack_mode() {
+        // Only #101 maps into the stack; #999 doesn't. With one covered chip
+        // the stack ordering is no improvement over legacy → fall back.
+        let other = stack_other(vec![999, 101], vec![entry("feat/a", Some(101), 1)]);
+        let cfg = ChipsConfig::default();
+        assert!(stack_ordered_urls(&other, cfg.force_stack).is_none());
+    }
+
+    #[test]
+    fn chips_force_stack_engages_with_one_covered() {
+        // force_stack overrides the ≥2 covered rule.
+        let other = stack_other(vec![999, 101], vec![entry("feat/a", Some(101), 1)]);
+        let ordered = stack_ordered_urls(&other, true).expect("forced");
+        assert_eq!(ordered, vec![url(101), url(999)]);
+    }
+
+    #[test]
+    fn chips_xs_collapses_to_count() {
+        // Xs path returns empty (component is dropped); the ×N collapse lives
+        // at S/M.
+        let (session, git, other_def, burn, agents) = mkctx();
+        let other = stack_other(
+            vec![101, 102, 103],
+            vec![
+                entry("feat/a", Some(101), 1),
+                entry("feat/b", Some(102), 2),
+                entry("feat/c", Some(103), 3),
+            ],
+        );
+        let _ = other_def; // unused; replaced
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = ChipsConfig::default();
+        let xs = Chips.render(Size::Xs, &cfg, &ctx);
+        assert!(xs.text.is_empty(), "Xs drops chips entirely");
+
+        let m = Chips.render(Size::M, &cfg, &ctx);
+        assert!(m.text.contains("×3"), "M collapses to ×N count: {}", m.text);
+
+        let xl = Chips.render(Size::Xl, &cfg, &ctx);
+        assert!(xl.text.contains("#101"), "Xl shows full chain: {}", xl.text);
+        assert!(xl.text.contains("#103"));
+        // Stack separator present and trunk-first ordering: #101 appears
+        // before #103 in the rendered string.
+        let p101 = xl.text.find("#101").unwrap();
+        let p103 = xl.text.find("#103").unwrap();
+        assert!(p101 < p103, "trunk-first order");
+        assert!(
+            xl.text.contains(&cfg.stack_separator),
+            "uses configured stack separator"
+        );
+    }
+
+    #[test]
+    fn chips_legacy_render_when_no_stack() {
+        // Without is_gt and without force_stack, the legacy leading PR_OPEN
+        // glyph is rendered and no stack separator appears.
+        let (session, git, _other_def, burn, agents) = mkctx();
+        let other = OtherPrs {
+            urls: vec![url(101), url(102)],
+            ..Default::default()
+        };
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = ChipsConfig::default();
+        let r = Chips.render(Size::Xl, &cfg, &ctx);
+        assert!(r.text.contains("#101"));
+        assert!(r.text.contains("#102"));
+        assert!(
+            !r.text.contains(&cfg.stack_separator),
+            "no stack separator in legacy mode"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 // Falls back to ~/.config/cc-statusbar/config.toml. Env vars override file.
 
 use crate::component::ComponentConfig;
-use crate::components::CtxBarConfig;
+use crate::components::{ChipsConfig, CtxBarConfig};
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -93,7 +93,7 @@ pub struct Config {
     #[serde(default)]
     pub ticket: Option<ComponentConfig>,
     #[serde(default)]
-    pub chips: Option<ComponentConfig>,
+    pub chips: ChipsConfig,
     #[serde(default)]
     pub burn: Option<ComponentConfig>,
     #[serde(default)]
@@ -146,6 +146,9 @@ impl Config {
     pub fn other_cache_ttl(&self) -> i64 {
         self.other_cache_ttl.unwrap_or(600)
     }
+    pub fn stack_refresh_ttl(&self) -> i64 {
+        self.chips.stack_refresh_ttl
+    }
     pub fn recent_prs_ttl(&self) -> i64 {
         self.recent_prs_ttl.unwrap_or(20)
     }
@@ -175,7 +178,7 @@ impl Config {
             "ahead" => pick(&self.ahead),
             "behind" => pick(&self.behind),
             "ticket" => pick(&self.ticket),
-            "chips" => pick(&self.chips),
+            "chips" => self.chips.common.clone(),
             "burn" => pick(&self.burn),
             "agents" => pick(&self.agents),
             "quotas" => pick(&self.quotas),

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,10 @@ fn main() {
                 refresh::run_refresh_other(&args[2]);
                 return;
             }
+            "--refresh-stack" => {
+                refresh::run_refresh_stack(&args[2]);
+                return;
+            }
             _ => {}
         }
     }
@@ -91,6 +95,7 @@ fn render_once() {
     // tick the freshest data is in place.
     refresh::maybe_spawn_pr(&session.session_id, &session.cwd, &handle.state);
     refresh::maybe_spawn_other(&session.session_id, &session.transcript, &handle.state);
+    refresh::maybe_spawn_stack(&session.session_id, &session.cwd, &handle.state);
     recent_prs::maybe_spawn_refresh();
 
     handle.state.tick = handle.state.tick.wrapping_add(1);

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -13,6 +13,7 @@ use std::process::{Command, Stdio};
 
 const ENV_CWD: &str = "CC_STATUSLINE_REFRESH_CWD";
 const ENV_TRANSCRIPT: &str = "CC_STATUSLINE_REFRESH_TRANSCRIPT";
+const ENV_STACK_CWD: &str = "CC_STATUSLINE_STACK_CWD";
 
 pub fn maybe_spawn_pr(session_id: &str, cwd: &str, st: &state::State) {
     let ttl = config::config().pr_cache_ttl();
@@ -44,6 +45,24 @@ pub fn maybe_spawn_other(session_id: &str, transcript: &str, st: &state::State) 
         &["--refresh-other", session_id],
         &[(ENV_TRANSCRIPT, transcript)],
     );
+}
+
+/// Spawn an async refresh of the Graphite stack snapshot for `cwd`. Uses the
+/// same detached-respawn pattern as PR/other refreshes; the stack TTL is
+/// configurable (`[chips].stack_refresh_ttl`, default 60s). Also debounced by
+/// a `locked_at` field to prevent thundering-herd `gt` invocations.
+pub fn maybe_spawn_stack(session_id: &str, cwd: &str, st: &state::State) {
+    if cwd.is_empty() {
+        return;
+    }
+    let ttl = config::config().stack_refresh_ttl();
+    if state::fresh(st.stack.fetched_at, ttl) {
+        return;
+    }
+    if state::fresh(st.stack.locked_at, ttl.max(30)) {
+        return;
+    }
+    spawn_self(&["--refresh-stack", session_id], &[(ENV_STACK_CWD, cwd)]);
 }
 
 fn spawn_self(args: &[&str], envs: &[(&str, &str)]) {
@@ -160,6 +179,123 @@ pub fn run_refresh_other(session_id: &str) {
     // sessions. We just record the URL list and exit.
     handle.state.other_prs.locked_at = 0;
     let _ = handle.save();
+}
+
+/// Async Graphite stack refresh. Runs `gt log --json` in $CWD; on success,
+/// flattens the JSON into a trunk-first list of `StackEntry`. On any failure
+/// (gt missing, non-zero exit, malformed JSON), `is_gt` stays `false` so the
+/// chips component falls back to its legacy ascending-PR-number rendering —
+/// no error surface to the user.
+pub fn run_refresh_stack(session_id: &str) {
+    let cwd = std::env::var(ENV_STACK_CWD).unwrap_or_default();
+    if cwd.is_empty() {
+        return;
+    }
+    let mut handle = match StateLock::acquire_blocking(session_id) {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+    let ttl = config::config().stack_refresh_ttl();
+    if state::fresh(handle.state.stack.fetched_at, ttl) {
+        return;
+    }
+    handle.state.stack.locked_at = now_epoch();
+    let _ = handle.save();
+
+    let (is_gt, entries) = fetch_stack(&cwd);
+    handle.state.stack.is_gt = is_gt;
+    handle.state.stack.entries = entries;
+    handle.state.stack.fetched_at = now_epoch();
+    handle.state.stack.locked_at = 0;
+    let _ = handle.save();
+}
+
+fn fetch_stack(cwd: &str) -> (bool, Vec<state::StackEntry>) {
+    let out = match Command::new("gt")
+        .args(["log", "--json"])
+        .current_dir(cwd)
+        .stderr(Stdio::null())
+        .output()
+    {
+        Ok(o) if o.status.success() && !o.stdout.is_empty() => o.stdout,
+        _ => return (false, Vec::new()),
+    };
+    let v: serde_json::Value = match serde_json::from_slice(&out) {
+        Ok(v) => v,
+        Err(_) => return (false, Vec::new()),
+    };
+    // `gt log --json` emits a flat array of entries. Each entry has at least
+    // `branch`, `parentBranch` (null for trunk), and optionally `prNumber`.
+    // We tolerate a top-level object containing the array under e.g.
+    // "branches" or "log" — best-effort to insulate against minor schema
+    // shifts in newer gt versions.
+    let arr = if let Some(a) = v.as_array() {
+        a.clone()
+    } else if let Some(a) = v.get("branches").and_then(|x| x.as_array()) {
+        a.clone()
+    } else if let Some(a) = v.get("log").and_then(|x| x.as_array()) {
+        a.clone()
+    } else {
+        return (false, Vec::new());
+    };
+    if arr.is_empty() {
+        return (false, Vec::new());
+    }
+    // Build branch→parent map and a branch→pr map.
+    use std::collections::HashMap;
+    let mut parent: HashMap<String, Option<String>> = HashMap::new();
+    let mut pr_of: HashMap<String, Option<u32>> = HashMap::new();
+    for e in &arr {
+        let branch = e
+            .get("branch")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string();
+        if branch.is_empty() {
+            continue;
+        }
+        let parent_branch = e
+            .get("parentBranch")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string());
+        let pr = e.get("prNumber").and_then(|x| x.as_u64()).map(|n| n as u32);
+        parent.insert(branch.clone(), parent_branch);
+        pr_of.insert(branch, pr);
+    }
+    // Compute depth for each branch by walking up to a root (parent==None or
+    // missing). Cap walk length to avoid pathological cycles.
+    let mut entries: Vec<state::StackEntry> = parent
+        .keys()
+        .map(|b| state::StackEntry {
+            branch: b.clone(),
+            pr: pr_of.get(b).copied().flatten(),
+            depth: depth_of(b, &parent),
+        })
+        .collect();
+    entries.sort_by_key(|e| (e.depth, e.branch.clone()));
+    (true, entries)
+}
+
+fn depth_of(start: &str, parent: &std::collections::HashMap<String, Option<String>>) -> u32 {
+    let mut d: u32 = 0;
+    let mut cur = start.to_string();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    loop {
+        if !seen.insert(cur.clone()) {
+            break; // cycle guard
+        }
+        match parent.get(&cur) {
+            Some(Some(p)) if !p.is_empty() => {
+                d += 1;
+                cur = p.clone();
+            }
+            _ => break,
+        }
+        if d > 64 {
+            break;
+        }
+    }
+    d
 }
 
 /// Fetch states for many PRs in one GraphQL call instead of N `gh pr view`s.

--- a/src/state.rs
+++ b/src/state.rs
@@ -29,6 +29,7 @@ pub struct State {
     pub focus: FocusState,
     pub pr: PrCache,
     pub other_prs: OtherPrCache,
+    pub stack: StackCache,
     pub burn: BurnCache,
     pub agents: AgentCache,
     /// Monotonic render counter. Drives the spinner so it advances exactly one
@@ -65,6 +66,34 @@ pub struct OtherPrCache {
     pub urls: Vec<String>,
     /// Raw JSON object: {url -> {state, isDraft}}.
     pub states_json: String,
+}
+
+/// Graphite stack snapshot for the current worktree. Populated asynchronously
+/// by `--refresh-other` (runs `gt log --json` in $CWD) and consumed by the
+/// chips component to render PRs in trunk→leaf order with stack separators.
+///
+/// `is_gt` is `true` only when `gt` is on $PATH AND `gt log --json` parsed
+/// cleanly into at least one entry. On any failure we leave it `false` and
+/// chips falls back to its legacy ascending-PR-number rendering — there is no
+/// error surface visible to the user.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct StackCache {
+    pub fetched_at: i64,
+    pub locked_at: i64,
+    pub is_gt: bool,
+    /// Trunk-first list of branches in the stack reachable from the worktree.
+    pub entries: Vec<StackEntry>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct StackEntry {
+    pub branch: String,
+    /// PR number, if Graphite knows about one for this branch.
+    pub pr: Option<u32>,
+    /// Distance from trunk; trunk is depth 0, first child is 1, etc.
+    pub depth: u32,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -32,6 +32,18 @@ fn origin_to_repo(origin_url: &str) -> String {
 pub struct OtherPrs {
     pub urls: Vec<String>,
     pub states: HashMap<String, PrStateLite>,
+    /// Whether the current worktree is a Graphite stack (gt log --json
+    /// succeeded). When true, `stack_entries` is non-empty and trunk-first.
+    pub is_gt: bool,
+    /// Trunk-first branches with optional PR numbers and depth-from-trunk.
+    pub stack_entries: Vec<StackChipEntry>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct StackChipEntry {
+    pub branch: String,
+    pub pr: Option<u32>,
+    pub depth: u32,
 }
 
 #[derive(Debug, Default)]
@@ -65,6 +77,17 @@ pub fn other_prs_view(st: &State, origin_url: &str) -> OtherPrs {
             );
         }
     }
+    out.is_gt = st.stack.is_gt;
+    out.stack_entries = st
+        .stack
+        .entries
+        .iter()
+        .map(|e| StackChipEntry {
+            branch: e.branch.clone(),
+            pr: e.pr,
+            depth: e.depth,
+        })
+        .collect();
     out
 }
 


### PR DESCRIPTION
## Summary

When `gt` is on `$PATH` and `gt log --json` succeeds in `$CWD`, the chips component now renders other-PR chips in **trunk → leaf** order, joined with a configurable stack separator (default `─•─`) and prefixed by a leading glyph (default Nerd Font branch, dim cyan). PRs not reachable from trunk are appended after the stacked chain in ascending PR-number order — identical to the legacy fallback — so non-Graphite workflows are visually unchanged.

Detection runs asynchronously on the same detached `--refresh-*` pattern as PR/other refreshes; the foreground render never blocks on `gt`. Results live in the per-session state TOML, debounced by both a TTL and a `locked_at` lock to prevent thundering-herd `gt` invocations.

Closes #2.

## Key decisions

- **Stack data lives in per-session state TOML, not a sibling `stack.json`.** The plan suggested a separate file. Reusing the existing `StateLock`-protected TOML keeps locking semantics identical to PR/other caches, gives us free version-bump invalidation (per `STATE_VERSION`), and avoids a third concurrency primitive. Same TTL/lock fields (`fetched_at` / `locked_at`) used by `PrCache` and `OtherPrCache`.
- **New `--refresh-stack <session>` subcommand**, mirroring `--refresh-pr` / `--refresh-other`. Cleaner than overloading `--refresh-other`, and lets stack TTL be tuned independently.
- **`ChipsConfig` flattens `ComponentConfig`** like `CtxBarConfig` does. Existing `[chips]` keys (`priority`, `min`, `default`, `required`) keep working unchanged; the new keys (`stack_separator`, `stack_glyph`, `force_stack`, `stack_refresh_ttl`) live in the same block. All behavior flows through the `Component` trait — no ad-hoc gating leaked into `layout.rs`.
- **`gt log --json` schema is consumed defensively**: tolerates a top-level array, `{branches:[…]}`, or `{log:[…]}`; computes depth by walking `parentBranch` with a cycle guard; ignores entries without a `branch` field. Anything malformed falls back to `is_gt=false` silently.
- **Stack mode requires ≥2 covered chips** (overridable via `force_stack=true`). One matched chip is no improvement over the legacy ordering, so we don't pay the visual reorder cost for it.

## Edge cases (all silent fallback)

| Case | Behavior |
|---|---|
| `gt` not on `$PATH` | `is_gt=false`; legacy chip rendering. |
| `gt log` non-zero exit / malformed JSON | `is_gt=false`. |
| `cwd` empty | refresh is skipped entirely. |
| Empty stack | `is_gt=false`. |
| <2 chips covered by stack | legacy ordering, unless `force_stack=true`. |
| PRs not reachable from trunk | appended after stacked chain, sorted ascending by PR number. |

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 16 tests pass, including 7 new chip tests:
  - `chips_stack_orders_by_depth` — scrambled discovered URLs render trunk-first.
  - `chips_uncovered_prs_appended_after_stack` — uncovered chips after stacked chain.
  - `chips_fallback_when_not_gt` — `is_gt=false` ⇒ no stack ordering.
  - `chips_requires_two_covered_for_stack_mode` — single covered chip falls back.
  - `chips_force_stack_engages_with_one_covered` — `force_stack=true` overrides the ≥2 rule.
  - `chips_xs_collapses_to_count` — Xs drops chips, M renders `×N`, Xl renders full chain with separator.
  - `chips_legacy_render_when_no_stack` — legacy `PR_OPEN` glyph + space-separated chips, no separator.

## Files

- `src/state.rs` — `StackCache { is_gt, fetched_at, locked_at, entries }` + `StackEntry { branch, pr, depth }`.
- `src/refresh.rs` — `maybe_spawn_stack` + `run_refresh_stack` + `fetch_stack` (`gt log --json`).
- `src/transcript.rs` — `OtherPrs` extended with `is_gt` + `stack_entries`; populated by `other_prs_view`.
- `src/components.rs` — `ChipsConfig`, `stack_ordered_urls`, stack-mode rendering in `Chips::render`.
- `src/config.rs` — `chips: ChipsConfig` + `stack_refresh_ttl()` accessor.
- `src/main.rs` — wires `--refresh-stack` subcommand + spawn.
- `Cargo.toml` — bump `0.1.3` → `0.1.4`.
- `CHANGELOG.md`, `config.example.toml` — docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)