### PR TITLE
feat: unified percentage display modes (Closes #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-04-29
+
+### Added
+
+- Unified percentage display modes (`PctMode`) shared by every percent-aware
+  component. New `mode` key on `[ctx_bar]`, `[quotas]`, and `[burn]`:
+  - `percent` (default) — `47%`
+  - `float`             — `0.47`
+  - `dots`              — single cell, 9 steps via braille `⠀⡀⡄⡆⡇⣇⣧⣷⣿`
+  - `shaded`            — single cell, 5 steps ` ░▒▓█`
+  - `hbar`              — multi-cell horizontal bar with sub-cell precision
+                          via `▏▎▍▌▋▊▉█` (replaces the old fixed-glyph blocks
+                          look — set `mode = "hbar"` to bring back the bar)
+  - `vbar`              — single cell, 8 vertical levels `▁▂▃▄▅▆▇█`
+  Color thresholds (red ≥80%, yellow ≥50%, dim otherwise) are unified in the
+  shared `pct::bar_color` so every component uses the same breakpoints.
+  (#10, closes #10)
+- `[burn].max_tokens_per_hour` (default `5_000_000`) — the ceiling against
+  which `tokens_per_hour` is mapped to a percent for the visual modes. The
+  text modes (`percent`, `float`) keep the legacy `Σ <human>/hr` rendering.
+- `[quotas]` is now a real config block (was unit). Quotas always renders
+  `<glyph> <pct-via-mode> (<reset>)` — the reset-time suffix lives outside
+  the mode-rendered glyph so users can switch the percent visual to
+  `dots`/`hbar` without losing the reset clock.
+
+### Changed
+
+- `[ctx_bar]` no longer has dedicated `width`/`filled`/`empty` keys at the
+  top level; they're now part of the shared `[pct]` knobs (and still parse
+  identically — old configs work unchanged, treated as overrides for `hbar`
+  mode glyphs). The default mode is `percent`, so existing renders that
+  relied on `[ctx_bar]` defaults will now show `47%` instead of the bar.
+  Set `mode = "hbar"` to restore the bar look.
+
 ## [0.1.5] - 2026-04-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "cc-statusline"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-statusline"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version = "1.89"
 description = "Claude Code statusline — Rust port of the bash original"

--- a/config.example.toml
+++ b/config.example.toml
@@ -74,12 +74,51 @@ overflow_chips_to_second_row = true
 #
 # Component-specific fields are documented per block below.
 
+# ─── Shared percent-display modes ──────────────────────────────────────────
+#
+# Every percent-aware component (`ctx_bar`, `quotas`, `burn`) shares the same
+# `mode` knob plus optional `width`/`filled`/`empty` overrides. Available
+# modes:
+#
+#   "percent"  -> "47%"
+#   "float"    -> "0.47"
+#   "dots"     -> single cell, 9 levels:  ⠀⡀⡄⡆⡇⣇⣧⣷⣿
+#   "shaded"   -> single cell, 5 levels:  ' ░▒▓█'
+#   "hbar"     -> multi-cell horizontal bar with sub-cell precision via
+#                 ▏▎▍▌▋▊▉█ (configurable via `width`/`filled`/`empty`)
+#   "vbar"     -> single cell, 8 vertical levels: ▁▂▃▄▅▆▇█
+#
+# `width` only matters for `hbar`. `filled`/`empty` only matter for `hbar`
+# (they're ignored in every other mode but still parse cleanly for back-compat
+# with older configs).
+
 [ctx_bar]
 priority = 90
 default  = "m"
-width    = 10
-filled   = "▓"
-empty    = "░"
+# mode = "percent"   # default — just renders "47%"
+# mode = "hbar"      # multi-cell bar, sub-cell precision
+# mode = "dots"      # one-cell braille meter
+# mode = "shaded"    # one-cell shade ramp
+# mode = "vbar"      # one-cell vertical bar
+# mode = "float"     # "0.47"
+# width  = 10
+# filled = "█"
+# empty  = " "
+
+[quotas]
+# Same `mode` options as ctx_bar. Reset-time suffix (e.g. "(2h30m)") is
+# appended regardless of mode, so switching to `dots`/`hbar` doesn't lose
+# the reset clock.
+# mode = "percent"
+
+[burn]
+priority = 8
+# `burn` doesn't have a native percent — it's derived from
+# `tokens_per_hour / max_tokens_per_hour`. The text modes (`percent`,
+# `float`) keep the legacy `Σ 1.5M/hr` rendering. The visual modes
+# (`dots`/`shaded`/`hbar`/`vbar`) replace the text with a colored meter.
+# mode = "percent"
+# max_tokens_per_hour = 5_000_000
 
 [chips]
 priority = 5
@@ -98,9 +137,6 @@ stack_refresh_ttl = 60
 
 [model]
 priority = 80
-
-[burn]
-priority = 8
 
 [spinner]
 priority = 100

--- a/src/components.rs
+++ b/src/components.rs
@@ -7,6 +7,7 @@
 use crate::component::{Component, RenderCtx, Rendered, Size};
 use crate::git::CiState;
 use crate::glyphs::*;
+use crate::pct::{self, PctConfig, PctMode};
 use crate::quota::{self, WIN_5H, WIN_7D};
 use serde::Deserialize;
 
@@ -584,9 +585,38 @@ fn human_burn(n: u64) -> String {
     }
 }
 
+/// Per-component config for `burn`. Inherits the shared `[pct]` knobs (`mode`,
+/// `width`, `filled`, `empty`) plus the burn-specific `max_tokens_per_hour`
+/// ceiling used to derive a percent. Default mode is `percent`, which
+/// preserves the legacy `Σ <human>/hr` text rendering. The visual modes
+/// (`dots`, `shaded`, `hbar`, `vbar`) replace the text with a bar; `float`
+/// also keeps the legacy text format.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct BurnConfig {
+    /// Tokens-per-hour value treated as 100%. Picked to map typical burn
+    /// rates (1M–3M/hr) to the 20–60% range so the visual modes are
+    /// meaningful without saturating to red.
+    pub max_tokens_per_hour: u64,
+    #[serde(flatten)]
+    pub pct: PctConfig,
+    #[serde(flatten)]
+    pub common: crate::component::ComponentConfig,
+}
+
+impl Default for BurnConfig {
+    fn default() -> Self {
+        Self {
+            max_tokens_per_hour: 5_000_000,
+            pct: PctConfig::default(),
+            common: crate::component::ComponentConfig::default(),
+        }
+    }
+}
+
 pub struct Burn;
 impl Component for Burn {
-    type Config = ();
+    type Config = BurnConfig;
     fn name() -> &'static str {
         "burn"
     }
@@ -596,14 +626,32 @@ impl Component for Burn {
     fn default_size() -> Size {
         Size::Xl
     }
-    fn render(&self, size: Size, _cfg: &(), ctx: &RenderCtx) -> Rendered {
+    fn render(&self, size: Size, cfg: &BurnConfig, ctx: &RenderCtx) -> Rendered {
         if ctx.burn.tokens_per_hour == 0 || size == Size::Xs {
             return Rendered::empty();
         }
-        let h = human_burn(ctx.burn.tokens_per_hour);
-        match size {
-            Size::Xl => Rendered::from_text(format!("{DIM}Σ{RESET} {h}{DIM}/hr{RESET}")),
-            _ => Rendered::from_text(format!("{DIM}Σ{RESET} {h}")),
+        // For text-y modes, keep the legacy `Σ <human>/hr` look.
+        match cfg.pct.mode {
+            PctMode::Percent | PctMode::Float => {
+                let h = human_burn(ctx.burn.tokens_per_hour);
+                let text = match size {
+                    Size::Xl => format!("{DIM}Σ{RESET} {h}{DIM}/hr{RESET}"),
+                    _ => format!("{DIM}Σ{RESET} {h}"),
+                };
+                Rendered::from_text(text)
+            }
+            _ => {
+                // Visual modes: render the percent bar derived from the
+                // configurable ceiling.
+                let max = cfg.max_tokens_per_hour.max(1);
+                let pct = ((ctx.burn.tokens_per_hour as u128 * 100) / max as u128).min(100) as u32;
+                let body = pct::render(pct, &cfg.pct);
+                let text = match size {
+                    Size::Xl => format!("{DIM}Σ{RESET} {body}{DIM}/hr{RESET}"),
+                    _ => format!("{DIM}Σ{RESET} {body}"),
+                };
+                Rendered::from_text(text)
+            }
         }
     }
 }
@@ -641,9 +689,23 @@ impl Component for Agents {
 
 // ─── quotas ─────────────────────────────────────────────────────────────
 
+/// Per-component config for `quotas`. Inherits the shared `[pct]` knobs
+/// (`mode`, `width`, `filled`, `empty`). Default mode is `percent` to
+/// preserve the legacy `<glyph> 47%` text. The reset-time suffix is appended
+/// by `quota::fmt_quota` regardless of mode, so users can switch the percent
+/// visual to `dots`/`hbar` without losing the reset clock.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct QuotasConfig {
+    #[serde(flatten)]
+    pub pct: PctConfig,
+    #[serde(flatten)]
+    pub common: crate::component::ComponentConfig,
+}
+
 pub struct Quotas;
 impl Component for Quotas {
-    type Config = ();
+    type Config = QuotasConfig;
     fn name() -> &'static str {
         "quotas"
     }
@@ -653,10 +715,10 @@ impl Component for Quotas {
     fn default_size() -> Size {
         Size::M
     }
-    fn render(&self, _size: Size, _cfg: &(), ctx: &RenderCtx) -> Rendered {
+    fn render(&self, _size: Size, cfg: &QuotasConfig, ctx: &RenderCtx) -> Rendered {
         let s = ctx.session;
-        let q5 = quota::fmt_quota(s.r5h, s.r5h_reset, WIN_5H, CLOCK_5H);
-        let q7 = quota::fmt_quota(s.r7d, s.r7d_reset, WIN_7D, CALENDAR_7D);
+        let q5 = quota::fmt_quota(s.r5h, s.r5h_reset, WIN_5H, CLOCK_5H, &cfg.pct);
+        let q7 = quota::fmt_quota(s.r7d, s.r7d_reset, WIN_7D, CALENDAR_7D, &cfg.pct);
         let mut out = String::new();
         if !q5.is_empty() {
             out.push_str(&q5);
@@ -676,60 +738,24 @@ impl Component for Quotas {
 
 // ─── ctx_bar ────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Deserialize)]
+/// Per-component config for `ctx_bar`. Inherits the shared `[pct]` knobs
+/// (`mode`, `width`, `filled`, `empty`) via `serde(flatten)` — meaning the
+/// existing `[ctx_bar]` blocks with `width = 10`, `filled = "▓"`, `empty =
+/// "░"` continue to parse unchanged. They're treated as overrides for the
+/// `hbar` mode glyphs.
+///
+/// Default mode is `percent` (a plain `47%`); set `mode = "hbar"` to bring
+/// back the bar look (now with sub-cell precision via the eighths glyphs).
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct CtxBarConfig {
-    pub width: u32,
-    pub filled: String,
-    pub empty: String,
-    /// Common ComponentConfig fields lifted into the same TOML block. Lets
-    /// users write:
-    ///   [ctx_bar]
-    ///   priority = 9
-    ///   width = 10
-    ///   filled = "▓"
+    #[serde(flatten)]
+    pub pct: PctConfig,
     #[serde(flatten)]
     pub common: crate::component::ComponentConfig,
 }
-impl Default for CtxBarConfig {
-    fn default() -> Self {
-        Self {
-            width: 10,
-            filled: "▓".into(),
-            empty: "░".into(),
-            common: crate::component::ComponentConfig::default(),
-        }
-    }
-}
 
 pub struct CtxBar;
-
-fn bar_color(pct: u32) -> &'static str {
-    if pct >= 80 {
-        FG_RED
-    } else if pct >= 50 {
-        FG_YELLOW
-    } else {
-        DIM
-    }
-}
-
-fn build_bar(pct: u32, bw: u32, filled: &str, empty: &str) -> String {
-    let mut f = pct * bw / 100;
-    if f > bw {
-        f = bw;
-    }
-    let e = bw - f;
-    let mut s = String::new();
-    for _ in 0..f {
-        s.push_str(filled);
-    }
-    for _ in 0..e {
-        s.push_str(empty);
-    }
-    let c = bar_color(pct);
-    format!("{c}{s}{RESET}")
-}
 
 impl Component for CtxBar {
     type Config = CtxBarConfig;
@@ -744,28 +770,48 @@ impl Component for CtxBar {
     }
     fn render(&self, size: Size, cfg: &CtxBarConfig, ctx: &RenderCtx) -> Rendered {
         let pct = ctx.session.ctx_pct;
+        // Per-size visual:
+        //   Xs   one-cell `dots` glyph, regardless of configured mode (a
+        //        single percent doesn't read at one cell anyway).
+        //   S    just the percent text via the configured mode.
+        //   M    mode-rendered visual, plus a trailing `47%` text for legibility.
+        //   L    M + leading CTX glyph.
+        //   Xl   L + trailing `/ 200k tokens` annotation.
         match size {
             Size::Xs => {
-                // One cell, no number. Use the filled glyph if any progress,
-                // otherwise the empty glyph.
-                let g = if pct > 0 { &cfg.filled } else { &cfg.empty };
-                let c = bar_color(pct);
-                Rendered::from_text(format!("{c}{g}{RESET}"))
+                let dots_cfg = PctConfig {
+                    mode: PctMode::Dots,
+                    ..cfg.pct.clone()
+                };
+                Rendered::from_text(pct::render(pct, &dots_cfg))
             }
-            Size::S => Rendered::from_text(format!("{}%", pct)),
+            Size::S => Rendered::from_text(pct::render(pct, &cfg.pct)),
             Size::M => {
-                let bar = build_bar(pct, cfg.width, &cfg.filled, &cfg.empty);
-                Rendered::from_text(format!("{bar} {pct}%"))
+                let body = pct::render(pct, &cfg.pct);
+                // For the textual modes don't double-print the percent.
+                if matches!(cfg.pct.mode, PctMode::Percent | PctMode::Float) {
+                    Rendered::from_text(body)
+                } else {
+                    Rendered::from_text(format!("{body} {pct}%"))
+                }
             }
             Size::L => {
-                let bar = build_bar(pct, cfg.width, &cfg.filled, &cfg.empty);
-                Rendered::from_text(format!("{DIM}{CTX}{RESET} {bar} {pct}%"))
+                let body = pct::render(pct, &cfg.pct);
+                if matches!(cfg.pct.mode, PctMode::Percent | PctMode::Float) {
+                    Rendered::from_text(format!("{DIM}{CTX}{RESET} {body}"))
+                } else {
+                    Rendered::from_text(format!("{DIM}{CTX}{RESET} {body} {pct}%"))
+                }
             }
             Size::Xl => {
-                let bar = build_bar(pct, cfg.width, &cfg.filled, &cfg.empty);
-                Rendered::from_text(format!(
-                    "{DIM}Σ{RESET} {bar} {pct}% {DIM}/ 200k tokens{RESET}"
-                ))
+                let body = pct::render(pct, &cfg.pct);
+                if matches!(cfg.pct.mode, PctMode::Percent | PctMode::Float) {
+                    Rendered::from_text(format!("{DIM}Σ{RESET} {body} {DIM}/ 200k tokens{RESET}"))
+                } else {
+                    Rendered::from_text(format!(
+                        "{DIM}Σ{RESET} {body} {pct}% {DIM}/ 200k tokens{RESET}"
+                    ))
+                }
             }
         }
     }
@@ -933,9 +979,9 @@ pub fn render_named(name: &str, size: Size, ctx: &RenderCtx) -> Option<Rendered>
         "behind" => Behind.render(size, &(), ctx),
         "ticket" => Ticket.render(size, &(), ctx),
         "chips" => Chips.render(size, &cfg.chips, ctx),
-        "burn" => Burn.render(size, &(), ctx),
+        "burn" => Burn.render(size, &cfg.burn, ctx),
         "agents" => Agents.render(size, &(), ctx),
-        "quotas" => Quotas.render(size, &(), ctx),
+        "quotas" => Quotas.render(size, &cfg.quotas, ctx),
         "ctx_bar" => CtxBar.render(size, &cfg.ctx_bar, ctx),
         "loc" => Loc.render(size, &(), ctx),
         "model" => Model.render(size, &(), ctx),
@@ -1100,6 +1146,207 @@ mod tests {
         let xs = bar.render(Size::Xs, &cfg, &ctx).width;
         let xl = bar.render(Size::Xl, &cfg, &ctx).width;
         assert!(xl > xs);
+    }
+
+    #[test]
+    fn ctx_bar_hbar_mode_renders_bar_glyphs() {
+        let (mut session, git, other, burn, agents) = mkctx();
+        session.ctx_pct = 50;
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = CtxBarConfig {
+            pct: PctConfig {
+                mode: PctMode::Hbar,
+                width: 10,
+                filled: "█".into(),
+                empty: " ".into(),
+            },
+            ..CtxBarConfig::default()
+        };
+        let r = CtxBar.render(Size::M, &cfg, &ctx);
+        assert!(
+            r.text.contains("█"),
+            "hbar should render block glyph: {}",
+            r.text
+        );
+        assert!(
+            r.text.contains("50%"),
+            "M size should still show percent suffix"
+        );
+    }
+
+    #[test]
+    fn ctx_bar_dots_mode_one_cell() {
+        let (mut session, git, other, burn, agents) = mkctx();
+        session.ctx_pct = 50;
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = CtxBarConfig {
+            pct: PctConfig {
+                mode: PctMode::Dots,
+                ..PctConfig::default()
+            },
+            ..CtxBarConfig::default()
+        };
+        let r = CtxBar.render(Size::S, &cfg, &ctx);
+        assert!(r.text.contains("⡇"), "dots@50%% → ⡇: {}", r.text);
+    }
+
+    #[test]
+    fn quotas_dots_mode_renders_braille_glyph() {
+        let (mut session, git, other, burn, agents) = mkctx();
+        session.r5h = Some(50);
+        session.r5h_reset = None;
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = QuotasConfig {
+            pct: PctConfig {
+                mode: PctMode::Dots,
+                ..PctConfig::default()
+            },
+            ..QuotasConfig::default()
+        };
+        let r = Quotas.render(Size::M, &cfg, &ctx);
+        assert!(
+            r.text.contains("⡇"),
+            "quotas dots@50%% should contain ⡇: {}",
+            r.text
+        );
+    }
+
+    #[test]
+    fn quotas_hbar_mode_renders_bar() {
+        let (mut session, git, other, burn, agents) = mkctx();
+        session.r7d = Some(80);
+        session.r7d_reset = None;
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = QuotasConfig {
+            pct: PctConfig {
+                mode: PctMode::Hbar,
+                width: 5,
+                filled: "█".into(),
+                empty: " ".into(),
+            },
+            ..QuotasConfig::default()
+        };
+        let r = Quotas.render(Size::M, &cfg, &ctx);
+        assert!(
+            r.text.contains("█"),
+            "quotas hbar should contain █: {}",
+            r.text
+        );
+    }
+
+    #[test]
+    fn burn_dots_mode_renders_braille_glyph() {
+        let (session, git, other, _burn_default, agents) = mkctx();
+        let burn = crate::transcript::BurnInfo {
+            tokens_per_hour: 2_500_000, // 50% of default 5M ceiling
+            tokens_total: 0,
+        };
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = BurnConfig {
+            pct: PctConfig {
+                mode: PctMode::Dots,
+                ..PctConfig::default()
+            },
+            ..BurnConfig::default()
+        };
+        let r = Burn.render(Size::Xl, &cfg, &ctx);
+        assert!(
+            r.text.contains("⡇"),
+            "burn dots@50%% should contain ⡇: {}",
+            r.text
+        );
+    }
+
+    #[test]
+    fn burn_hbar_mode_renders_bar() {
+        let (session, git, other, _burn_default, agents) = mkctx();
+        let burn = crate::transcript::BurnInfo {
+            tokens_per_hour: 5_000_000, // 100% at default ceiling
+            tokens_total: 0,
+        };
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = BurnConfig {
+            pct: PctConfig {
+                mode: PctMode::Hbar,
+                width: 4,
+                filled: "█".into(),
+                empty: " ".into(),
+            },
+            ..BurnConfig::default()
+        };
+        let r = Burn.render(Size::Xl, &cfg, &ctx);
+        assert!(
+            r.text.contains("████"),
+            "burn hbar@100%% should fill: {}",
+            r.text
+        );
+    }
+
+    #[test]
+    fn burn_percent_mode_keeps_legacy_text() {
+        let (session, git, other, _b, agents) = mkctx();
+        let burn = crate::transcript::BurnInfo {
+            tokens_per_hour: 1_500_000,
+            tokens_total: 0,
+        };
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = BurnConfig::default(); // mode = percent
+        let r = Burn.render(Size::Xl, &cfg, &ctx);
+        assert!(
+            r.text.contains("1.5M"),
+            "percent mode keeps human-burn text: {}",
+            r.text
+        );
+        assert!(r.text.contains("/hr"));
     }
 
     fn url(n: u32) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 // Falls back to ~/.config/cc-statusbar/config.toml. Env vars override file.
 
 use crate::component::ComponentConfig;
-use crate::components::{ChipsConfig, CtxBarConfig};
+use crate::components::{BurnConfig, ChipsConfig, CtxBarConfig, QuotasConfig};
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -99,11 +99,11 @@ pub struct Config {
     #[serde(default)]
     pub chips: ChipsConfig,
     #[serde(default)]
-    pub burn: Option<ComponentConfig>,
+    pub burn: BurnConfig,
     #[serde(default)]
     pub agents: Option<ComponentConfig>,
     #[serde(default)]
-    pub quotas: Option<ComponentConfig>,
+    pub quotas: QuotasConfig,
     #[serde(default)]
     pub ctx_bar: CtxBarConfig,
     #[serde(default)]
@@ -183,9 +183,9 @@ impl Config {
             "behind" => pick(&self.behind),
             "ticket" => pick(&self.ticket),
             "chips" => self.chips.common.clone(),
-            "burn" => pick(&self.burn),
+            "burn" => self.burn.common.clone(),
             "agents" => pick(&self.agents),
-            "quotas" => pick(&self.quotas),
+            "quotas" => self.quotas.common.clone(),
             "ctx_bar" => self.ctx_bar.common.clone(),
             "loc" => pick(&self.loc),
             "model" => pick(&self.model),

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod git;
 mod glyphs;
 mod input;
 mod layout;
+mod pct;
 mod quota;
 mod recent_prs;
 mod refresh;

--- a/src/pct.rs
+++ b/src/pct.rs
@@ -1,0 +1,390 @@
+// Unified percentage display modes shared by all percent-aware components
+// (ctx_bar, quotas, …).
+//
+// `PctMode` selects the rendering family; `PctConfig` carries the per-mode
+// knobs (bar width and the hbar-mode filled/empty glyph overrides). `render`
+// turns a 0..=100 integer percent into a colored string via `bar_color`
+// (the same red/yellow/dim breakpoints used by the original `ctx_bar`).
+//
+// Modes:
+//   percent   "47%"
+//   float     "0.47"      (always 2 decimals, no '%')
+//   dots      1 cell, 9 steps:   ⠀⡀⡄⡆⡇⣇⣧⣷⣿
+//   shaded    1 cell, 5 steps:   ' ', ░, ▒, ▓, █
+//   hbar      `width` cells, full █ + partial ▏▎▍▌▋▊▉ for the leading sub-cell
+//             (default — replaces the old `blocks` look with sub-cell precision)
+//   vbar      1 cell, 8 vertical levels:   ▁▂▃▄▅▆▇█
+
+use crate::glyphs::{DIM, FG_RED, FG_YELLOW, RESET};
+use serde::Deserialize;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PctMode {
+    #[default]
+    Percent,
+    Float,
+    Dots,
+    Shaded,
+    Hbar,
+    Vbar,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct PctConfig {
+    pub mode: PctMode,
+    pub width: u32,
+    /// Override for the full-cell glyph in `hbar` mode. Defaults to `█`.
+    pub filled: String,
+    /// Override for the empty-cell glyph in `hbar` mode. Defaults to a single
+    /// space so the bar reads cleanly as "filled to here, empty after".
+    pub empty: String,
+}
+
+impl Default for PctConfig {
+    fn default() -> Self {
+        Self {
+            mode: PctMode::Percent,
+            width: 10,
+            filled: "█".into(),
+            empty: " ".into(),
+        }
+    }
+}
+
+/// Red ≥80%, yellow ≥50%, dim otherwise. Single source of truth for every
+/// percent-aware component's colour band.
+pub fn bar_color(pct: u32) -> &'static str {
+    if pct >= 80 {
+        FG_RED
+    } else if pct >= 50 {
+        FG_YELLOW
+    } else {
+        DIM
+    }
+}
+
+/// 9-step braille ramp: 0/8…8/8.
+const DOTS_STEPS: [&str; 9] = ["⠀", "⡀", "⡄", "⡆", "⡇", "⣇", "⣧", "⣷", "⣿"];
+
+/// 5-step shade ramp: 0/4…4/4. The first step is a literal space cell so the
+/// glyph still occupies one column.
+const SHADED_STEPS: [&str; 5] = [" ", "░", "▒", "▓", "█"];
+
+/// 8-step vertical bar ramp: 1/8…8/8. Index 0 is "empty" — a literal space so
+/// the cell still occupies one column.
+const VBAR_STEPS: [&str; 9] = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+/// 7 partial-eighth glyphs (1/8…7/8).
+const HBAR_PARTIAL: [&str; 7] = ["▏", "▎", "▍", "▌", "▋", "▊", "▉"];
+
+fn clamp_pct(pct: u32) -> u32 {
+    pct.min(100)
+}
+
+fn render_percent(pct: u32) -> String {
+    format!("{pct}%")
+}
+
+fn render_float(pct: u32) -> String {
+    let whole = pct / 100;
+    let frac = pct % 100;
+    format!("{whole}.{frac:02}")
+}
+
+fn render_dots(pct: u32) -> String {
+    // 9 buckets, evenly distributed across 0..=100. Use rounding so that
+    // exact step boundaries (k/8 of 100) land on bucket k.
+    let idx = ((pct as u64 * 8 + 50) / 100) as usize;
+    let idx = idx.min(8);
+    DOTS_STEPS[idx].to_string()
+}
+
+fn render_shaded(pct: u32) -> String {
+    // 5 buckets across 0..=100 with rounding.
+    let idx = ((pct as u64 * 4 + 50) / 100) as usize;
+    let idx = idx.min(4);
+    SHADED_STEPS[idx].to_string()
+}
+
+fn render_vbar(pct: u32) -> String {
+    // 9 buckets (0..=8), rounded.
+    let idx = ((pct as u64 * 8 + 50) / 100) as usize;
+    let idx = idx.min(8);
+    VBAR_STEPS[idx].to_string()
+}
+
+fn render_hbar(pct: u32, width: u32, filled: &str, empty: &str) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    // Total eighth-units across the bar.
+    let total_eighths = (width as u64) * 8;
+    let filled_eighths = (pct as u64 * total_eighths) / 100;
+    let full_cells = (filled_eighths / 8) as u32;
+    let partial = (filled_eighths % 8) as usize;
+
+    let mut s = String::new();
+    for _ in 0..full_cells {
+        s.push_str(filled);
+    }
+    let mut emitted = full_cells;
+    if partial > 0 && emitted < width {
+        s.push_str(HBAR_PARTIAL[partial - 1]);
+        emitted += 1;
+    }
+    while emitted < width {
+        s.push_str(empty);
+        emitted += 1;
+    }
+    s
+}
+
+/// Render a percent (0..=100; clamped above) using `cfg`. Wraps the visible
+/// glyph(s) in the appropriate colour code from `bar_color`.
+pub fn render(pct: u32, cfg: &PctConfig) -> String {
+    let body = render_plain(pct, cfg);
+    let c = bar_color(clamp_pct(pct));
+    format!("{c}{body}{RESET}")
+}
+
+/// Strip the colour wrapping for tests / inspection. Useful when callers want
+/// to compose the rendered glyphs with their own styling (e.g. `quotas`
+/// wrapping with pace-aware colour from `quota::pct_color`).
+pub fn render_plain(pct: u32, cfg: &PctConfig) -> String {
+    let pct = clamp_pct(pct);
+    match cfg.mode {
+        PctMode::Percent => render_percent(pct),
+        PctMode::Float => render_float(pct),
+        PctMode::Dots => render_dots(pct),
+        PctMode::Shaded => render_shaded(pct),
+        PctMode::Hbar => render_hbar(pct, cfg.width, &cfg.filled, &cfg.empty),
+        PctMode::Vbar => render_vbar(pct),
+    }
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(mode: PctMode) -> PctConfig {
+        PctConfig {
+            mode,
+            ..PctConfig::default()
+        }
+    }
+
+    fn cfg_w(mode: PctMode, width: u32) -> PctConfig {
+        PctConfig {
+            mode,
+            width,
+            ..PctConfig::default()
+        }
+    }
+
+    fn cfg_blocks(width: u32) -> PctConfig {
+        // hbar with the legacy `▓`/`░` glyphs — exercises the override path.
+        PctConfig {
+            mode: PctMode::Hbar,
+            width,
+            filled: "▓".into(),
+            empty: "░".into(),
+        }
+    }
+
+    // ── percent ──
+
+    #[test]
+    fn percent_basic() {
+        assert_eq!(render_plain(0, &cfg(PctMode::Percent)), "0%");
+        assert_eq!(render_plain(50, &cfg(PctMode::Percent)), "50%");
+        assert_eq!(render_plain(100, &cfg(PctMode::Percent)), "100%");
+    }
+
+    // ── float ──
+
+    #[test]
+    fn float_basic() {
+        assert_eq!(render_plain(0, &cfg(PctMode::Float)), "0.00");
+        assert_eq!(render_plain(50, &cfg(PctMode::Float)), "0.50");
+        assert_eq!(render_plain(100, &cfg(PctMode::Float)), "1.00");
+    }
+
+    #[test]
+    fn float_boundaries() {
+        assert_eq!(render_plain(0, &cfg(PctMode::Float)), "0.00");
+        assert_eq!(render_plain(1, &cfg(PctMode::Float)), "0.01");
+        assert_eq!(render_plain(99, &cfg(PctMode::Float)), "0.99");
+        assert_eq!(render_plain(100, &cfg(PctMode::Float)), "1.00");
+    }
+
+    // ── dots ──
+
+    #[test]
+    fn dots_basic() {
+        assert_eq!(render_plain(0, &cfg(PctMode::Dots)), "⠀");
+        assert_eq!(render_plain(50, &cfg(PctMode::Dots)), "⡇"); // 4/8
+        assert_eq!(render_plain(100, &cfg(PctMode::Dots)), "⣿");
+    }
+
+    #[test]
+    fn dots_nine_step_boundaries() {
+        // pct ≈ round(k/8 * 100) for k in 0..=8
+        // k:   0   1   2   3   4   5   6   7   8
+        // pct: 0  12  25  38  50  62  75  88  100
+        let cases = [
+            (0u32, "⠀"),
+            (12, "⡀"),
+            (25, "⡄"),
+            (38, "⡆"),
+            (50, "⡇"),
+            (62, "⣇"),
+            (75, "⣧"),
+            (88, "⣷"),
+            (100, "⣿"),
+        ];
+        for (pct, want) in cases {
+            assert_eq!(render_plain(pct, &cfg(PctMode::Dots)), want, "pct={pct}");
+        }
+    }
+
+    // ── shaded ──
+
+    #[test]
+    fn shaded_basic() {
+        assert_eq!(render_plain(0, &cfg(PctMode::Shaded)), " ");
+        assert_eq!(render_plain(50, &cfg(PctMode::Shaded)), "▒"); // 2/4
+        assert_eq!(render_plain(100, &cfg(PctMode::Shaded)), "█");
+    }
+
+    #[test]
+    fn shaded_five_step_boundaries() {
+        // k:   0   1   2   3   4
+        // pct: 0  25  50  75  100
+        let cases = [(0u32, " "), (25, "░"), (50, "▒"), (75, "▓"), (100, "█")];
+        for (pct, want) in cases {
+            assert_eq!(render_plain(pct, &cfg(PctMode::Shaded)), want, "pct={pct}");
+        }
+    }
+
+    // ── vbar ──
+
+    #[test]
+    fn vbar_basic() {
+        assert_eq!(render_plain(0, &cfg(PctMode::Vbar)), " ");
+        assert_eq!(render_plain(50, &cfg(PctMode::Vbar)), "▄"); // 4/8
+        assert_eq!(render_plain(100, &cfg(PctMode::Vbar)), "█");
+    }
+
+    #[test]
+    fn vbar_eight_step_boundaries() {
+        // k:   0   1   2   3   4   5   6   7   8
+        // pct: 0  12  25  38  50  62  75  88  100
+        let cases = [
+            (0u32, " "),
+            (12, "▁"),
+            (25, "▂"),
+            (38, "▃"),
+            (50, "▄"),
+            (62, "▅"),
+            (75, "▆"),
+            (88, "▇"),
+            (100, "█"),
+        ];
+        for (pct, want) in cases {
+            assert_eq!(render_plain(pct, &cfg(PctMode::Vbar)), want, "pct={pct}");
+        }
+    }
+
+    // ── hbar (sub-cell + legacy override) ──
+
+    #[test]
+    fn hbar_basic_width_4() {
+        let c = cfg_w(PctMode::Hbar, 4);
+        assert_eq!(render_plain(0, &c), "    ");
+        // 50% of 4 cells = 2 full cells, 2 empty (default empty = ' ').
+        assert_eq!(render_plain(50, &c), "██  ");
+        assert_eq!(render_plain(100, &c), "████");
+    }
+
+    #[test]
+    fn hbar_partial_glyph_at_each_eighth_width_1() {
+        // With width=1, partial = (pct*8/100). Pick percentages that floor
+        // exactly to k/8 for k in 1..=7.
+        // pct=13: 13*8/100=1 -> ▏
+        // pct=25: 25*8/100=2 -> ▎
+        // pct=38: 38*8/100=3 -> ▍
+        // pct=50: 50*8/100=4 -> ▌
+        // pct=63: 63*8/100=5 -> ▋
+        // pct=75: 75*8/100=6 -> ▊
+        // pct=88: 88*8/100=7 -> ▉
+        let c = cfg_w(PctMode::Hbar, 1);
+        assert_eq!(render_plain(13, &c), "▏");
+        assert_eq!(render_plain(25, &c), "▎");
+        assert_eq!(render_plain(38, &c), "▍");
+        assert_eq!(render_plain(50, &c), "▌");
+        assert_eq!(render_plain(63, &c), "▋");
+        assert_eq!(render_plain(75, &c), "▊");
+        assert_eq!(render_plain(88, &c), "▉");
+        // 100% snaps to a single full block.
+        assert_eq!(render_plain(100, &c), "█");
+    }
+
+    #[test]
+    fn hbar_legacy_blocks_glyphs() {
+        // Override `filled`/`empty` to the legacy `▓`/`░` look — exercises the
+        // back-compat path for users with existing `[ctx_bar]` configs.
+        let c = cfg_blocks(10);
+        assert_eq!(render_plain(0, &c), "░░░░░░░░░░");
+        // 50% of 10 = 5 full cells, no partial, 5 empty cells.
+        assert_eq!(render_plain(50, &c), "▓▓▓▓▓░░░░░");
+        assert_eq!(render_plain(100, &c), "▓▓▓▓▓▓▓▓▓▓");
+    }
+
+    // ── clamping & zero ──
+
+    #[test]
+    fn clamp_above_100() {
+        let c = cfg_blocks(4);
+        assert_eq!(render_plain(150, &c), "▓▓▓▓");
+        assert_eq!(render_plain(101, &cfg(PctMode::Percent)), "100%");
+        assert_eq!(render_plain(200, &cfg(PctMode::Float)), "1.00");
+        assert_eq!(render_plain(999, &cfg(PctMode::Dots)), "⣿");
+        assert_eq!(render_plain(101, &cfg(PctMode::Shaded)), "█");
+        assert_eq!(render_plain(500, &cfg(PctMode::Vbar)), "█");
+    }
+
+    #[test]
+    fn zero_renders_all_empty_blocks() {
+        let c = cfg_blocks(5);
+        assert_eq!(render_plain(0, &c), "░░░░░");
+    }
+
+    #[test]
+    fn zero_renders_all_empty_hbar() {
+        let c = cfg_w(PctMode::Hbar, 5);
+        assert_eq!(render_plain(0, &c), "     ");
+    }
+
+    // ── color wrapping ──
+
+    #[test]
+    fn render_wraps_with_color_codes() {
+        let s = render(50, &cfg(PctMode::Percent));
+        assert!(s.contains("50%"));
+        assert!(s.contains(RESET));
+    }
+
+    #[test]
+    fn bar_color_thresholds() {
+        assert_eq!(bar_color(0), DIM);
+        assert_eq!(bar_color(49), DIM);
+        assert_eq!(bar_color(50), FG_YELLOW);
+        assert_eq!(bar_color(79), FG_YELLOW);
+        assert_eq!(bar_color(80), FG_RED);
+        assert_eq!(bar_color(100), FG_RED);
+    }
+}

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -3,6 +3,7 @@
 
 use crate::cache::now_epoch;
 use crate::glyphs::{DIM, FG_RED, FG_YELLOW, RESET};
+use crate::pct::{self, PctConfig};
 
 pub const WIN_5H: i64 = 18_000;
 pub const WIN_7D: i64 = 604_800;
@@ -87,13 +88,25 @@ pub fn reset_str(reset: i64) -> String {
     format!("{} {}", clock.trim_start(), dur)
 }
 
-pub fn fmt_quota(p: Option<u32>, reset: Option<i64>, window: i64, label: &str) -> String {
+/// Render a single quota window. The percent visual is delegated to
+/// `pct::render_plain` using `pct_cfg`, so callers can swap between text
+/// (`percent`/`float`) and bar visuals (`dots`/`shaded`/`hbar`/`vbar`). The
+/// reset-time suffix is unconditional (when present) and lives outside the
+/// mode-rendered glyph: `<glyph> <pct-rendered> (<reset>)`.
+pub fn fmt_quota(
+    p: Option<u32>,
+    reset: Option<i64>,
+    window: i64,
+    label: &str,
+    pct_cfg: &PctConfig,
+) -> String {
     let p = match p {
         Some(p) => p,
         None => return String::new(),
     };
     let c = pct_color(p, reset, window);
-    let mut out = format!("{c}{label} {p}%");
+    let body = pct::render_plain(p, pct_cfg);
+    let mut out = format!("{c}{label} {body}");
     if p >= 80 {
         if let Some(r) = reset {
             out.push_str(&format!(" ({})", reset_str(r)));


### PR DESCRIPTION
## Summary

- New `src/pct.rs` defines `PctMode` (percent | float | dots | shaded | hbar | vbar) and `PctConfig`, plus a shared `bar_color` helper. One `render(pct, &cfg)` API used by every percent-aware component.
- `ctx_bar`, `quotas`, and `burn` now share the same `mode` knob (and `width`/`filled`/`empty` overrides for `hbar`). `quotas` promoted from a unit config to `QuotasConfig`; `burn` gains `BurnConfig` with `max_tokens_per_hour` for the percent derivation.
- Reset-time suffix on `quotas` lives outside the mode-rendered glyph, so switching to `dots`/`hbar` doesn't lose the reset clock.
- `burn`'s text modes (`percent`, `float`) keep the legacy `Σ <human>/hr` rendering; visual modes replace the text with a colored meter against the configurable ceiling.
- Existing `[ctx_bar]` configs with `width`/`filled`/`empty` still parse — those keys flatten into `PctConfig` and act as `hbar`-mode overrides.
- Default mode for all three is `percent`. To restore the old bar look on `ctx_bar`, set `mode = "hbar"`.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all clean
- [x] Tests in `src/pct.rs` cover all 6 modes at 0/50/100%, plus boundary cases (`dots` 9 steps, `shaded` 5 steps, `vbar` 9 steps, `hbar` partial-glyph at each eighth, `float` boundaries 0/1/99/100, clamping above 100, zero renders all-empty)
- [x] Component tests verify `ctx_bar`, `quotas`, and `burn` all honor `dots` and `hbar` modes
- [x] `burn_percent_mode_keeps_legacy_text` confirms text mode preserves `Σ 1.5M/hr`
- [x] Cargo.toml bumped 0.1.5 → 0.1.6, CHANGELOG entry added
- [x] `config.example.toml` documents `mode` plus all variants under `[ctx_bar]`, `[quotas]`, and `[burn]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)