### PR TITLE
feat: JSON schema for config.toml (Closes #13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,7 @@ jobs:
       - run: cargo test
       - run: cargo clippy -- -D warnings
       - run: cargo fmt --check
+      - name: schema up-to-date
+        run: |
+          cargo run --bin gen_schema > /tmp/schema.json
+          diff -u config.schema.json /tmp/schema.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-04-29
+
+### Added
+
+- JSON schema for `config.toml`, generated from the config structs via
+  `schemars`. New `gen_schema` binary emits `config.schema.json` to stdout;
+  the committed schema lives at the repo root and is checked in CI for
+  drift. `config.example.toml` ships with a `#:schema` directive so editors
+  with the Even Better TOML extension light up autocomplete and validation
+  out of the box. (Closes #13)
+
+### Changed
+
+- The crate now exposes a library target (`cc_statusline`) alongside the
+  existing `cc-statusline` binary so external binaries (currently
+  `gen_schema`) can reach the config types. Installs are unchanged —
+  `cargo install --path .` still produces `cc-statusline`.
+
 ## [0.1.6] - 2026-04-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,13 +13,20 @@ dependencies = [
 
 [[package]]
 name = "cc-statusline"
-version = "0.1.6"
+version = "0.1.8"
 dependencies = [
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "toml",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -103,6 +110,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +157,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,30 @@
 [package]
 name = "cc-statusline"
-version = "0.1.6"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.89"
 description = "Claude Code statusline — Rust port of the bash original"
 license = "MIT"
 repository = "https://github.com/NorthIsUp/cc-statusline"
 
+[lib]
+name = "cc_statusline"
+path = "src/lib.rs"
+
 [[bin]]
 name = "cc-statusline"
 path = "src/main.rs"
+
+[[bin]]
+name = "gen_schema"
+path = "src/bin/gen_schema.rs"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = "1"
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
+schemars = { version = "0.8", features = ["derive"] }
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ Hysteresis: once a component is shrunk at terminal width W, it stays
 shrunk while cols stays within ±`hysteresis_band` of W. Decisions
 persist in `state.toml` so the line doesn't oscillate as you nudge-resize.
 
+## Editor support
+
+A JSON schema for `config.toml` lives at the repo root as
+`config.schema.json`. Point editors at it for autocomplete and validation.
+
+With the [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)
+VS Code extension, add a `#:schema` directive to the top of your
+`config.toml`:
+
+```toml
+#:schema https://raw.githubusercontent.com/NorthIsUp/cc-statusline/main/config.schema.json
+```
+
+To regenerate the schema after changing config structs:
+
+```sh
+cargo run --bin gen_schema > config.schema.json
+```
+
+CI diffs the committed schema against `gen_schema` output, so any
+struct change must come with a regenerated `config.schema.json`.
+
 ## Releasing
 
 1. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`.

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,3 +1,4 @@
+#:schema https://raw.githubusercontent.com/NorthIsUp/cc-statusline/main/config.schema.json
 # Example: $XDG_CONFIG_HOME/cc-statusbar/config.toml
 # Every field is optional; defaults match the bash original.
 # Env vars (LINEAR_WORKSPACE, CC_STATUSLINE_*) take precedence over file values.

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,665 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Config",
+  "type": "object",
+  "properties": {
+    "agents": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ahead": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "behind": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "branch": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "burn": {
+      "$ref": "#/definitions/BurnConfig"
+    },
+    "chips": {
+      "$ref": "#/definitions/ChipsConfig"
+    },
+    "ci": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "comments": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ctx_bar": {
+      "$ref": "#/definitions/CtxBarConfig"
+    },
+    "debug_focus_log": {
+      "default": null,
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "dirty": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "effort": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "layout": {
+      "description": "`[layout]` block — left/right component lists, gap, autoresize, etc.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LayoutConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "linear_workspace": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "loc": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "model": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nerd_font_width": {
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "other_cache_ttl": {
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "pr_cache_ttl": {
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "pr_expand_min_cols": {
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "pr_icon": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "pr_num": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "quotas": {
+      "$ref": "#/definitions/QuotasConfig"
+    },
+    "recent_prs_ttl": {
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "repo": {
+      "description": "Per-component common config blocks. Each component's `[name]` block is parsed into a `ComponentConfig` (priority/min/sizes/required) plus component-specific extension fields handled separately.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "review": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "safety_margin": {
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "spinner": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "spinner_cfg": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ticket": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ComponentConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "BurnConfig": {
+      "description": "Per-component config for `burn`. Inherits the shared `[pct]` knobs (`mode`, `width`, `filled`, `empty`) plus the burn-specific `max_tokens_per_hour` ceiling used to derive a percent. Default mode is `percent`, which preserves the legacy `Σ <human>/hr` text rendering. The visual modes (`dots`, `shaded`, `hbar`, `vbar`) replace the text with a bar; `float` also keeps the legacy text format.",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Override of the default size. None = component's `default_size()`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "empty": {
+          "description": "Override for the empty-cell glyph in `hbar` mode. Defaults to a single space so the bar reads cleanly as \"filled to here, empty after\".",
+          "default": " ",
+          "type": "string"
+        },
+        "filled": {
+          "description": "Override for the full-cell glyph in `hbar` mode. Defaults to `█`.",
+          "default": "█",
+          "type": "string"
+        },
+        "max_tokens_per_hour": {
+          "description": "Tokens-per-hour value treated as 100%. Picked to map typical burn rates (1M–3M/hr) to the 20–60% range so the visual modes are meaningful without saturating to red.",
+          "default": 5000000,
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "min": {
+          "description": "Don't shrink past this size. None = component's smallest.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "mode": {
+          "$ref": "#/definitions/PctMode"
+        },
+        "priority": {
+          "description": "Higher = shrunk LAST when autoresizing. Default 5.",
+          "default": 5,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "required": {
+          "description": "If true, never drop entirely.",
+          "default": false,
+          "type": "boolean"
+        },
+        "sizes": {
+          "description": "Sizes the user has whitelisted. Empty = use the component's full set.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Size"
+          }
+        },
+        "width": {
+          "default": 10,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "ChipsConfig": {
+      "description": "`[chips]` config block. Common ComponentConfig fields (priority/min/sizes/ required/default) live alongside chips-specific stack-mode knobs.\n\nIn stack mode (Graphite detected and ≥2 chip PRs covered by the stack), chips are reordered by depth and joined with `stack_separator`, prefixed by `stack_glyph` in dim cyan. Set `force_stack=true` to use the stack layout even without `gt`; set `stack_glyph=\"\"` to suppress the leading glyph.",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Override of the default size. None = component's `default_size()`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "force_stack": {
+          "default": false,
+          "type": "boolean"
+        },
+        "min": {
+          "description": "Don't shrink past this size. None = component's smallest.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "priority": {
+          "description": "Higher = shrunk LAST when autoresizing. Default 5.",
+          "default": 5,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "required": {
+          "description": "If true, never drop entirely.",
+          "default": false,
+          "type": "boolean"
+        },
+        "sizes": {
+          "description": "Sizes the user has whitelisted. Empty = use the component's full set.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Size"
+          }
+        },
+        "stack_glyph": {
+          "default": "",
+          "type": "string"
+        },
+        "stack_refresh_ttl": {
+          "default": 60,
+          "type": "integer",
+          "format": "int64"
+        },
+        "stack_separator": {
+          "default": "─•─",
+          "type": "string"
+        }
+      }
+    },
+    "ComponentConfig": {
+      "description": "Common per-component config. Lives at the top of every `[name]` block.",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Override of the default size. None = component's `default_size()`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min": {
+          "description": "Don't shrink past this size. None = component's smallest.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "priority": {
+          "description": "Higher = shrunk LAST when autoresizing. Default 5.",
+          "default": 5,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "required": {
+          "description": "If true, never drop entirely.",
+          "default": false,
+          "type": "boolean"
+        },
+        "sizes": {
+          "description": "Sizes the user has whitelisted. Empty = use the component's full set.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Size"
+          }
+        }
+      }
+    },
+    "CtxBarConfig": {
+      "description": "Per-component config for `ctx_bar`. Inherits the shared `[pct]` knobs (`mode`, `width`, `filled`, `empty`) via `serde(flatten)` — meaning the existing `[ctx_bar]` blocks with `width = 10`, `filled = \"▓\"`, `empty = \"░\"` continue to parse unchanged. They're treated as overrides for the `hbar` mode glyphs.\n\nDefault mode is `percent` (a plain `47%`); set `mode = \"hbar\"` to bring back the bar look (now with sub-cell precision via the eighths glyphs).",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Override of the default size. None = component's `default_size()`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "empty": {
+          "description": "Override for the empty-cell glyph in `hbar` mode. Defaults to a single space so the bar reads cleanly as \"filled to here, empty after\".",
+          "default": " ",
+          "type": "string"
+        },
+        "filled": {
+          "description": "Override for the full-cell glyph in `hbar` mode. Defaults to `█`.",
+          "default": "█",
+          "type": "string"
+        },
+        "min": {
+          "description": "Don't shrink past this size. None = component's smallest.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "mode": {
+          "$ref": "#/definitions/PctMode"
+        },
+        "priority": {
+          "description": "Higher = shrunk LAST when autoresizing. Default 5.",
+          "default": 5,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "required": {
+          "description": "If true, never drop entirely.",
+          "default": false,
+          "type": "boolean"
+        },
+        "sizes": {
+          "description": "Sizes the user has whitelisted. Empty = use the component's full set.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Size"
+          }
+        },
+        "width": {
+          "default": 10,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "LayoutConfig": {
+      "type": "object",
+      "properties": {
+        "autoresize": {
+          "default": true,
+          "type": "boolean"
+        },
+        "gap": {
+          "default": 2,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "hysteresis_band": {
+          "default": 2,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "left": {
+          "default": [
+            "repo",
+            "pr_icon",
+            "branch",
+            "pr_num",
+            "ci",
+            "review",
+            "comments",
+            "dirty",
+            "ahead",
+            "behind",
+            "ticket",
+            "chips"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "overflow_chips_to_second_row": {
+          "description": "When `chips` collapses to its compact `×N` form, render the expanded `#a #b #c …` chain on a second row instead of dropping it.",
+          "default": true,
+          "type": "boolean"
+        },
+        "right": {
+          "default": [
+            "burn",
+            "agents",
+            "quotas",
+            "ctx_bar",
+            "loc",
+            "model",
+            "effort",
+            "spinner"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PctMode": {
+      "type": "string",
+      "enum": [
+        "percent",
+        "float",
+        "dots",
+        "shaded",
+        "hbar",
+        "vbar"
+      ]
+    },
+    "QuotasConfig": {
+      "description": "Per-component config for `quotas`. Inherits the shared `[pct]` knobs (`mode`, `width`, `filled`, `empty`). Default mode is `percent` to preserve the legacy `<glyph> 47%` text. The reset-time suffix is appended by `quota::fmt_quota` regardless of mode, so users can switch the percent visual to `dots`/`hbar` without losing the reset clock.",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Override of the default size. None = component's `default_size()`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "empty": {
+          "description": "Override for the empty-cell glyph in `hbar` mode. Defaults to a single space so the bar reads cleanly as \"filled to here, empty after\".",
+          "default": " ",
+          "type": "string"
+        },
+        "filled": {
+          "description": "Override for the full-cell glyph in `hbar` mode. Defaults to `█`.",
+          "default": "█",
+          "type": "string"
+        },
+        "min": {
+          "description": "Don't shrink past this size. None = component's smallest.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "mode": {
+          "$ref": "#/definitions/PctMode"
+        },
+        "priority": {
+          "description": "Higher = shrunk LAST when autoresizing. Default 5.",
+          "default": 5,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "required": {
+          "description": "If true, never drop entirely.",
+          "default": false,
+          "type": "boolean"
+        },
+        "sizes": {
+          "description": "Sizes the user has whitelisted. Empty = use the component's full set.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Size"
+          }
+        },
+        "width": {
+          "default": 10,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Size": {
+      "description": "Discrete size buckets a component can render at, smallest → largest.",
+      "type": "string",
+      "enum": [
+        "xs",
+        "s",
+        "m",
+        "l",
+        "xl"
+      ]
+    }
+  }
+}

--- a/src/bin/gen_schema.rs
+++ b/src/bin/gen_schema.rs
@@ -1,0 +1,11 @@
+// Emit the JSON schema for the `config.toml` Config struct on stdout.
+//
+// Run via `cargo run --bin gen_schema > config.schema.json`. CI diffs the
+// committed schema against this output to catch struct drift.
+
+use cc_statusline::config::Config;
+
+fn main() {
+    let schema = schemars::schema_for!(Config);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+}

--- a/src/component.rs
+++ b/src/component.rs
@@ -11,11 +11,13 @@
 use crate::git::GitData;
 use crate::input::Session;
 use crate::transcript::{AgentCount, BurnInfo, OtherPrs};
+use schemars::JsonSchema;
 use serde::Deserialize;
 use std::str::FromStr;
 
 /// Discrete size buckets a component can render at, smallest → largest.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, JsonSchema)]
+#[schemars(rename_all = "lowercase")]
 pub enum Size {
     Xs,
     S,
@@ -97,7 +99,7 @@ pub struct RenderCtx<'a> {
 }
 
 /// Common per-component config. Lives at the top of every `[name]` block.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct ComponentConfig {
     /// Sizes the user has whitelisted. Empty = use the component's full set.

--- a/src/components.rs
+++ b/src/components.rs
@@ -9,6 +9,7 @@ use crate::git::CiState;
 use crate::glyphs::*;
 use crate::pct::{self, PctConfig, PctMode};
 use crate::quota::{self, WIN_5H, WIN_7D};
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 // ─── helpers ────────────────────────────────────────────────────────────
@@ -405,7 +406,7 @@ impl Component for Ticket {
 /// by `stack_glyph` in dim cyan. Set `force_stack=true` to use the stack
 /// layout even without `gt`; set `stack_glyph=""` to suppress the leading
 /// glyph.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct ChipsConfig {
     pub stack_separator: String,
@@ -591,7 +592,7 @@ fn human_burn(n: u64) -> String {
 /// preserves the legacy `Σ <human>/hr` text rendering. The visual modes
 /// (`dots`, `shaded`, `hbar`, `vbar`) replace the text with a bar; `float`
 /// also keeps the legacy text format.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct BurnConfig {
     /// Tokens-per-hour value treated as 100%. Picked to map typical burn
@@ -694,7 +695,7 @@ impl Component for Agents {
 /// preserve the legacy `<glyph> 47%` text. The reset-time suffix is appended
 /// by `quota::fmt_quota` regardless of mode, so users can switch the percent
 /// visual to `dots`/`hbar` without losing the reset clock.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct QuotasConfig {
     #[serde(flatten)]
@@ -746,7 +747,7 @@ impl Component for Quotas {
 ///
 /// Default mode is `percent` (a plain `47%`); set `mode = "hbar"` to bring
 /// back the bar look (now with sub-cell precision via the eighths glyphs).
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct CtxBarConfig {
     #[serde(flatten)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,11 +3,12 @@
 
 use crate::component::ComponentConfig;
 use crate::components::{BurnConfig, ChipsConfig, CtxBarConfig, QuotasConfig};
+use schemars::JsonSchema;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct LayoutConfig {
     pub left: Vec<String>,
@@ -54,7 +55,7 @@ pub fn default_right() -> Vec<String> {
     .collect()
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct Config {
     pub linear_workspace: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,30 @@
+// Library crate — exposes the statusline's modules so external binaries (e.g.
+// `gen_schema`) can reach the config types. The main `cc-statusline` binary in
+// `src/main.rs` continues to live as a binary target with its own module tree;
+// this lib mirrors the same module set so both compile from the same sources.
+
+#![allow(
+    dead_code,
+    clippy::collapsible_if,
+    clippy::collapsible_match,
+    clippy::unnecessary_cast,
+    clippy::manual_range_contains
+)]
+
+pub mod cache;
+pub mod component;
+pub mod components;
+pub mod config;
+pub mod focus;
+pub mod git;
+pub mod glyphs;
+pub mod input;
+pub mod layout;
+pub mod pct;
+pub mod quota;
+pub mod recent_prs;
+pub mod refresh;
+pub mod render;
+pub mod state;
+pub mod transcript;
+pub mod vlen;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,24 +27,7 @@
     clippy::manual_range_contains
 )]
 
-mod cache;
-mod component;
-mod components;
-mod config;
-mod focus;
-mod git;
-mod glyphs;
-mod input;
-mod layout;
-mod pct;
-mod quota;
-mod recent_prs;
-mod refresh;
-mod render;
-mod state;
-mod transcript;
-mod vlen;
-
+use cc_statusline::{focus, git, input, recent_prs, refresh, render, state, transcript};
 use std::io::{self, Read};
 
 fn main() {

--- a/src/pct.rs
+++ b/src/pct.rs
@@ -16,10 +16,12 @@
 //   vbar      1 cell, 8 vertical levels:   ▁▂▃▄▅▆▇█
 
 use crate::glyphs::{DIM, FG_RED, FG_YELLOW, RESET};
+use schemars::JsonSchema;
 use serde::Deserialize;
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+#[schemars(rename_all = "lowercase")]
 pub enum PctMode {
     #[default]
     Percent,
@@ -30,7 +32,7 @@ pub enum PctMode {
     Vbar,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct PctConfig {
     pub mode: PctMode,


### PR DESCRIPTION
## Summary

- Adds `schemars` v0.8 derives to every config struct (`Config`, `LayoutConfig`, `ComponentConfig`, `Size`, `ChipsConfig`, `BurnConfig`, `QuotasConfig`, `CtxBarConfig`, `PctConfig`, `PctMode`).
- New `gen_schema` binary prints the schema to stdout. Committed output lives at `config.schema.json` (root).
- Promotes the crate to a `[lib]` (`cc_statusline`) + `[[bin]]` so `gen_schema` can reach the config types. Main `cc-statusline` binary still installs as before.
- `config.example.toml` ships with a `#:schema` directive pointing at the GitHub raw URL so VS Code (Even Better TOML) lights up autocomplete on copy.
- README gains an "Editor support" section documenting the directive and the regen command.
- CI gains a schema-up-to-date guard: regenerates the schema and `diff -u` against the committed file.
- Version bumped to 0.1.8 (0.1.7 already taken by the in-flight per-bucket quotas branch).

Schemars version: 0.8.22 (the 0.8 line) — produced a clean schema with `Option<ComponentConfig>` flatten patterns; no need to fall back to 0.9/1.0.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (all 46 lib tests pass; one is flaky under parallel runs, passes single-threaded — pre-existing)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo run --bin gen_schema` prints valid JSON
- [x] `diff config.schema.json <(cargo run --bin gen_schema)` clean

Closes #13

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)