### PR TITLE
feat: address quotas.<bucket> as layout entries (Closes #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-04-29
+
+### Added
+
+- Dotted layout entries `quotas.hourly`, `quotas.weekly`, `quotas.design`,
+  `quotas.sonnet`. Each addresses a single quota bucket so users can place
+  buckets at distinct layout positions, e.g.
+  `right = ["burn", "quotas.hourly", "ctx_bar", "quotas.weekly", "model"]`.
+  The bare `quotas` entry continues to render every configured bucket
+  joined with the existing `·` separator. Default priorities for the
+  dotted entries are higher than the bare parent (25 / 20 / 18 / 17 vs 15)
+  since explicitly-placed buckets are user-elevated.
+- Per-bucket layout knobs: `[quotas.hourly] priority = 30` (and `min`,
+  `required`, `default`, `sizes`) now flow through. The bucket sub-section
+  is a `BucketConfig` carrying both the percent fields (`mode`/`width`/...)
+  and the common `ComponentConfig` fields. (#16, closes #16)
+
+### Changed
+
+- `QuotasConfig.{hourly,weekly,design,sonnet}` field type changed from
+  `Option<PctConfig>` to `Option<BucketConfig>`. The on-disk TOML format
+  is unchanged — both `PctConfig` and `ComponentConfig` deserialize via
+  `serde(flatten)` so existing `[quotas.hourly] mode = "hbar"` configs
+  parse unchanged.
+
 ## [0.1.9] - 2026-04-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "cc-statusline"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "regex",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-statusline"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 rust-version = "1.89"
 description = "Claude Code statusline — Rust port of the bash original"

--- a/config.example.toml
+++ b/config.example.toml
@@ -57,6 +57,12 @@ right = [
   "effort",
   "spinner",
 ]
+# Tip: address individual quota buckets at separate layout positions with
+# the dotted form, e.g.
+#   right = ["burn", "quotas.hourly", "ctx_bar", "quotas.weekly", "model"]
+# Recognised dotted entries: quotas.hourly, quotas.weekly, quotas.design,
+# quotas.sonnet. The bare `quotas` entry still renders every configured
+# bucket joined with `·`.
 gap = 2
 autoresize = true
 hysteresis_band = 2
@@ -120,6 +126,7 @@ default  = "m"
 
 # [quotas.hourly]    # 5-hour bucket (rate_limits.five_hour)
 # mode = "vbar"
+# priority = 30      # elevate just this bucket when used as `quotas.hourly`
 
 # [quotas.weekly]    # 7-day bucket (rate_limits.seven_day)
 # mode = "hbar"

--- a/config.schema.json
+++ b/config.schema.json
@@ -261,6 +261,72 @@
     }
   },
   "definitions": {
+    "BucketConfig": {
+      "description": "Per-bucket override block. Carries both the percent-display fields (`mode`/`width`/`filled`/`empty`) and the layout `ComponentConfig` knobs (`priority`/`min`/`required`/...) — the latter let users elevate a single bucket's autoresize priority via e.g. `[quotas.hourly] priority = 30`.",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Override of the default size. None = component's `default_size()`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "empty": {
+          "description": "Override for the empty-cell glyph in `hbar` mode. Defaults to a single space so the bar reads cleanly as \"filled to here, empty after\".",
+          "default": " ",
+          "type": "string"
+        },
+        "filled": {
+          "description": "Override for the full-cell glyph in `hbar` mode. Defaults to `█`.",
+          "default": "█",
+          "type": "string"
+        },
+        "min": {
+          "description": "Don't shrink past this size. None = component's smallest.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "mode": {
+          "$ref": "#/definitions/PctMode"
+        },
+        "priority": {
+          "description": "Higher = shrunk LAST when autoresizing. Default 5.",
+          "default": 5,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "required": {
+          "description": "If true, never drop entirely.",
+          "default": false,
+          "type": "boolean"
+        },
+        "sizes": {
+          "description": "Sizes the user has whitelisted. Empty = use the component's full set.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Size"
+          }
+        },
+        "width": {
+          "default": 10,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
     "BurnConfig": {
       "description": "Per-component config for `burn`. Inherits the shared `[pct]` knobs (`mode`, `width`, `filled`, `empty`) plus the burn-specific `max_tokens_per_hour` ceiling used to derive a percent. Default mode is `percent`, which preserves the legacy `Σ <human>/hr` text rendering. The visual modes (`dots`, `shaded`, `hbar`, `vbar`) replace the text with a bar; `float` also keeps the legacy text format.",
       "type": "object",
@@ -573,30 +639,6 @@
         }
       }
     },
-    "PctConfig": {
-      "type": "object",
-      "properties": {
-        "empty": {
-          "description": "Override for the empty-cell glyph in `hbar` mode. Defaults to a single space so the bar reads cleanly as \"filled to here, empty after\".",
-          "default": " ",
-          "type": "string"
-        },
-        "filled": {
-          "description": "Override for the full-cell glyph in `hbar` mode. Defaults to `█`.",
-          "default": "█",
-          "type": "string"
-        },
-        "mode": {
-          "$ref": "#/definitions/PctMode"
-        },
-        "width": {
-          "default": 10,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
-        }
-      }
-    },
     "PctMode": {
       "type": "string",
       "enum": [
@@ -627,7 +669,7 @@
           "description": "Override for the design-partner bucket.",
           "anyOf": [
             {
-              "$ref": "#/definitions/PctConfig"
+              "$ref": "#/definitions/BucketConfig"
             },
             {
               "type": "null"
@@ -648,7 +690,7 @@
           "description": "Override for the 5-hour bucket (`rate_limits.five_hour`).",
           "anyOf": [
             {
-              "$ref": "#/definitions/PctConfig"
+              "$ref": "#/definitions/BucketConfig"
             },
             {
               "type": "null"
@@ -692,7 +734,7 @@
           "description": "Override for the sonnet model bucket.",
           "anyOf": [
             {
-              "$ref": "#/definitions/PctConfig"
+              "$ref": "#/definitions/BucketConfig"
             },
             {
               "type": "null"
@@ -703,7 +745,7 @@
           "description": "Override for the 7-day bucket (`rate_limits.seven_day`).",
           "anyOf": [
             {
-              "$ref": "#/definitions/PctConfig"
+              "$ref": "#/definitions/BucketConfig"
             },
             {
               "type": "null"

--- a/src/components.rs
+++ b/src/components.rs
@@ -707,13 +707,56 @@ pub struct QuotasConfig {
     #[serde(flatten)]
     pub common: crate::component::ComponentConfig,
     /// Override for the 5-hour bucket (`rate_limits.five_hour`).
-    pub hourly: Option<PctConfig>,
+    pub hourly: Option<BucketConfig>,
     /// Override for the 7-day bucket (`rate_limits.seven_day`).
-    pub weekly: Option<PctConfig>,
+    pub weekly: Option<BucketConfig>,
     /// Override for the design-partner bucket.
-    pub design: Option<PctConfig>,
+    pub design: Option<BucketConfig>,
     /// Override for the sonnet model bucket.
-    pub sonnet: Option<PctConfig>,
+    pub sonnet: Option<BucketConfig>,
+}
+
+/// Per-bucket override block. Carries both the percent-display fields
+/// (`mode`/`width`/`filled`/`empty`) and the layout `ComponentConfig` knobs
+/// (`priority`/`min`/`required`/...) — the latter let users elevate a single
+/// bucket's autoresize priority via e.g. `[quotas.hourly] priority = 30`.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct BucketConfig {
+    #[serde(flatten)]
+    pub pct: PctConfig,
+    #[serde(flatten)]
+    pub common: crate::component::ComponentConfig,
+}
+
+/// Which quota bucket to render. Used for the dotted-layout-entry routing
+/// (`quotas.hourly`, `quotas.weekly`, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BucketKind {
+    Hourly,
+    Weekly,
+    Design,
+    Sonnet,
+}
+
+impl BucketKind {
+    pub fn from_suffix(s: &str) -> Option<Self> {
+        Some(match s {
+            "hourly" => BucketKind::Hourly,
+            "weekly" => BucketKind::Weekly,
+            "design" => BucketKind::Design,
+            "sonnet" => BucketKind::Sonnet,
+            _ => return None,
+        })
+    }
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BucketKind::Hourly => "hourly",
+            BucketKind::Weekly => "weekly",
+            BucketKind::Design => "design",
+            BucketKind::Sonnet => "sonnet",
+        }
+    }
 }
 
 impl QuotasConfig {
@@ -722,19 +765,42 @@ impl QuotasConfig {
     /// `[quotas]` defaults are used. (We don't field-merge: `PctConfig` fields
     /// are tightly coupled — `mode = "hbar"` only makes sense alongside its
     /// own `width`/`filled`/`empty`.)
-    fn effective(&self, bucket: &Option<PctConfig>) -> PctConfig {
-        bucket.clone().unwrap_or_else(|| self.pct.clone())
+    fn effective(&self, bucket: &Option<BucketConfig>) -> PctConfig {
+        bucket
+            .as_ref()
+            .map(|b| b.pct.clone())
+            .unwrap_or_else(|| self.pct.clone())
+    }
+
+    fn bucket_for(&self, kind: BucketKind) -> &Option<BucketConfig> {
+        match kind {
+            BucketKind::Hourly => &self.hourly,
+            BucketKind::Weekly => &self.weekly,
+            BucketKind::Design => &self.design,
+            BucketKind::Sonnet => &self.sonnet,
+        }
     }
 }
 
-/// One quota bucket's render inputs. Grouped to keep the buckets array
-/// readable (a flat tuple form trips clippy::type_complexity).
-struct Bucket<'a> {
-    label: &'a str,
-    pct: Option<u32>,
-    reset: Option<i64>,
-    window: i64,
-    cfg: &'a Option<PctConfig>,
+/// Render a single quota bucket, returning `None` if the bucket has no data.
+pub fn render_one_bucket(cfg: &QuotasConfig, kind: BucketKind, ctx: &RenderCtx) -> Option<String> {
+    let s = ctx.session;
+    // Design/sonnet windows aren't documented upstream — use WIN_7D as a
+    // sane default so pace coloring degrades to the static threshold when
+    // `resets_at` is missing (which it currently always is).
+    let (label, pct, reset, window) = match kind {
+        BucketKind::Hourly => (CLOCK_5H, s.r5h, s.r5h_reset, WIN_5H),
+        BucketKind::Weekly => (CALENDAR_7D, s.r7d, s.r7d_reset, WIN_7D),
+        // design/sonnet: config plumbing exists, but the upstream session JSON
+        // paths aren't documented yet — pct stays None so these always render
+        // empty until follow-up work captures a real session payload and
+        // wires `Session::design`/`sonnet`.
+        BucketKind::Design => (DESIGN_Q, None, None, WIN_7D),
+        BucketKind::Sonnet => (SONNET_Q, None, None, WIN_7D),
+    };
+    let pcfg = cfg.effective(cfg.bucket_for(kind));
+    let q = quota::fmt_quota(pct, reset, window, label, &pcfg);
+    if q.is_empty() { None } else { Some(q) }
 }
 
 pub struct Quotas;
@@ -750,52 +816,17 @@ impl Component for Quotas {
         Size::M
     }
     fn render(&self, _size: Size, cfg: &QuotasConfig, ctx: &RenderCtx) -> Rendered {
-        let s = ctx.session;
         // Render order: hourly, weekly, design, sonnet. Skip empty buckets.
-        // Design/sonnet windows aren't documented upstream — use WIN_7D as a
-        // sane default so pace coloring degrades to the static threshold when
-        // `resets_at` is missing (which it currently always is).
-        let buckets = [
-            Bucket {
-                label: CLOCK_5H,
-                pct: s.r5h,
-                reset: s.r5h_reset,
-                window: WIN_5H,
-                cfg: &cfg.hourly,
-            },
-            Bucket {
-                label: CALENDAR_7D,
-                pct: s.r7d,
-                reset: s.r7d_reset,
-                window: WIN_7D,
-                cfg: &cfg.weekly,
-            },
-            // design/sonnet buckets: config plumbing exists, but the
-            // upstream session JSON paths aren't documented yet — pct stays
-            // None so these always render empty until follow-up work captures
-            // a real session payload and wires `Session::design`/`sonnet`.
-            Bucket {
-                label: DESIGN_Q,
-                pct: None,
-                reset: None,
-                window: WIN_7D,
-                cfg: &cfg.design,
-            },
-            Bucket {
-                label: SONNET_Q,
-                pct: None,
-                reset: None,
-                window: WIN_7D,
-                cfg: &cfg.sonnet,
-            },
-        ];
         let mut out = String::new();
-        for b in buckets {
-            let pcfg = cfg.effective(b.cfg);
-            let q = quota::fmt_quota(b.pct, b.reset, b.window, b.label, &pcfg);
-            if q.is_empty() {
+        for kind in [
+            BucketKind::Hourly,
+            BucketKind::Weekly,
+            BucketKind::Design,
+            BucketKind::Sonnet,
+        ] {
+            let Some(q) = render_one_bucket(cfg, kind, ctx) else {
                 continue;
-            }
+            };
             if !out.is_empty() {
                 out.push_str(&format!(" {DIM}·{RESET} "));
             }
@@ -1032,6 +1063,14 @@ impl Component for Spinner {
     }
 }
 
+/// Parse `quotas.<bucket>` layout entry names into a `BucketKind`. Returns
+/// `None` for the bare `"quotas"` name and for unknown sub-buckets like
+/// `"quotas.foo"`.
+pub fn quotas_bucket_kind(name: &str) -> Option<BucketKind> {
+    name.strip_prefix("quotas.")
+        .and_then(BucketKind::from_suffix)
+}
+
 // ─── registry-style dispatch ────────────────────────────────────────────
 
 /// Render a component by name at the given size. Returns `None` if the name
@@ -1054,6 +1093,13 @@ pub fn render_named(name: &str, size: Size, ctx: &RenderCtx) -> Option<Rendered>
         "burn" => Burn.render(size, &cfg.burn, ctx),
         "agents" => Agents.render(size, &(), ctx),
         "quotas" => Quotas.render(size, &cfg.quotas, ctx),
+        n if quotas_bucket_kind(n).is_some() => {
+            let kind = quotas_bucket_kind(n).unwrap();
+            match render_one_bucket(&cfg.quotas, kind, ctx) {
+                Some(text) => Rendered::from_text(text),
+                None => Rendered::empty(),
+            }
+        }
         "ctx_bar" => CtxBar.render(size, &cfg.ctx_bar, ctx),
         "loc" => Loc.render(size, &(), ctx),
         "model" => Model.render(size, &(), ctx),
@@ -1087,6 +1133,7 @@ pub fn sizes_for(name: &str) -> Option<&'static [Size]> {
         "burn" => Burn::sizes(),
         "agents" => Agents::sizes(),
         "quotas" => Quotas::sizes(),
+        n if quotas_bucket_kind(n).is_some() => Quotas::sizes(),
         "ctx_bar" => CtxBar::sizes(),
         "loc" => Loc::sizes(),
         "model" => Model::sizes(),
@@ -1113,6 +1160,7 @@ pub fn default_size_for(name: &str) -> Option<Size> {
         "burn" => Burn::default_size(),
         "agents" => Agents::default_size(),
         "quotas" => Quotas::default_size(),
+        n if quotas_bucket_kind(n).is_some() => Quotas::default_size(),
         "ctx_bar" => CtxBar::default_size(),
         "loc" => Loc::default_size(),
         "model" => Model::default_size(),
@@ -1143,6 +1191,10 @@ pub fn default_priority(name: &str) -> u32 {
         "comments" => 25,
         "repo" => 20,
         "quotas" => 15,
+        "quotas.hourly" => 25,
+        "quotas.weekly" => 20,
+        "quotas.design" => 18,
+        "quotas.sonnet" => 17,
         "agents" => 10,
         "burn" => 8,
         "chips" => 5,
@@ -1361,8 +1413,8 @@ mod tests {
             tick: 0,
         };
         let cfg = QuotasConfig {
-            design: Some(PctConfig::default()),
-            sonnet: Some(PctConfig::default()),
+            design: Some(BucketConfig::default()),
+            sonnet: Some(BucketConfig::default()),
             ..QuotasConfig::default()
         };
         let r = Quotas.render(Size::M, &cfg, &ctx);
@@ -1393,9 +1445,12 @@ mod tests {
                 mode: PctMode::Percent,
                 ..PctConfig::default()
             },
-            hourly: Some(PctConfig {
-                mode: PctMode::Vbar,
-                ..PctConfig::default()
+            hourly: Some(BucketConfig {
+                pct: PctConfig {
+                    mode: PctMode::Vbar,
+                    ..PctConfig::default()
+                },
+                ..BucketConfig::default()
             }),
             ..QuotasConfig::default()
         };
@@ -1443,6 +1498,171 @@ mod tests {
             "fallback red color present: {:?}",
             r.text
         );
+    }
+
+    #[test]
+    fn quotas_hourly_only_renders_hourly_glyph() {
+        // `quotas.hourly` dispatcher path renders ONLY the hourly bucket;
+        // weekly is absent even when r7d is populated.
+        let (mut session, git, other, burn, agents) = mkctx();
+        session.r5h = Some(40);
+        session.r7d = Some(60);
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let r = render_named("quotas.hourly", Size::M, &ctx).expect("dispatched");
+        assert!(
+            r.text.contains(CLOCK_5H),
+            "hourly glyph present: {}",
+            r.text
+        );
+        assert!(
+            !r.text.contains(CALENDAR_7D),
+            "weekly glyph absent: {}",
+            r.text
+        );
+    }
+
+    #[test]
+    fn quotas_weekly_only_renders_weekly_glyph() {
+        let (mut session, git, other, burn, agents) = mkctx();
+        session.r5h = Some(40);
+        session.r7d = Some(60);
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let r = render_named("quotas.weekly", Size::M, &ctx).expect("dispatched");
+        assert!(r.text.contains(CALENDAR_7D), "weekly glyph: {}", r.text);
+        assert!(!r.text.contains(CLOCK_5H), "no hourly: {}", r.text);
+    }
+
+    #[test]
+    fn quotas_unknown_bucket_drops_silently() {
+        // `quotas.foo` is not a known bucket — sizes_for/default_size_for must
+        // return None so the layout engine drops it, and render_named must
+        // also return None (not crash).
+        let (session, git, other, burn, agents) = mkctx();
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        assert!(sizes_for("quotas.foo").is_none());
+        assert!(default_size_for("quotas.foo").is_none());
+        assert!(render_named("quotas.foo", Size::M, &ctx).is_none());
+    }
+
+    #[test]
+    fn quotas_bare_entry_still_renders_all_buckets() {
+        // Back-compat: bare `quotas` renders both populated buckets joined.
+        let (mut session, git, other, burn, agents) = mkctx();
+        session.r5h = Some(40);
+        session.r7d = Some(60);
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let cfg = QuotasConfig::default();
+        let r = Quotas.render(Size::M, &cfg, &ctx);
+        assert!(r.text.contains(CLOCK_5H));
+        assert!(r.text.contains(CALENDAR_7D));
+    }
+
+    #[test]
+    fn quotas_hourly_and_weekly_at_separate_positions() {
+        // Simulate a layout where the two dotted entries sit at non-adjacent
+        // positions: ["burn", "quotas.hourly", "ctx_bar", "quotas.weekly"].
+        // Verify both render at their layout positions and ordering follows
+        // the layout (hourly comes before weekly).
+        let (mut session, git, other, _burn_default, agents) = mkctx();
+        session.r5h = Some(40);
+        session.r7d = Some(60);
+        let burn = crate::transcript::BurnInfo {
+            tokens_per_hour: 1_000_000,
+            tokens_total: 0,
+        };
+        let ctx = RenderCtx {
+            session: &session,
+            git: &git,
+            other: &other,
+            burn: &burn,
+            agents: &agents,
+            tick: 0,
+        };
+        let names = ["burn", "quotas.hourly", "ctx_bar", "quotas.weekly"];
+        let mut parts: Vec<String> = Vec::new();
+        for n in names {
+            let s = default_size_for(n).expect("known");
+            let r = render_named(n, s, &ctx).expect("dispatched");
+            if !r.text.is_empty() {
+                parts.push(r.text);
+            }
+        }
+        let joined = parts.join(" ");
+        let p_hourly = joined.find(CLOCK_5H).expect("hourly rendered");
+        let p_weekly = joined.find(CALENDAR_7D).expect("weekly rendered");
+        assert!(
+            p_hourly < p_weekly,
+            "hourly position precedes weekly: {joined}"
+        );
+        // Sanity: the bare quotas separator (" · ") does NOT appear between
+        // them — the two dotted entries are independent items, so the layout
+        // separator (a plain space) sits between them rather than the
+        // intra-bucket "·".
+        let between = &joined[p_hourly..p_weekly];
+        assert!(
+            !between.contains("·"),
+            "no intra-quotas separator between split buckets: {between}"
+        );
+    }
+
+    #[test]
+    fn quotas_dotted_default_priorities() {
+        assert_eq!(default_priority("quotas"), 15);
+        assert_eq!(default_priority("quotas.hourly"), 25);
+        assert_eq!(default_priority("quotas.weekly"), 20);
+        assert_eq!(default_priority("quotas.design"), 18);
+        assert_eq!(default_priority("quotas.sonnet"), 17);
+    }
+
+    #[test]
+    fn quotas_per_bucket_priority_override_via_bucket_common() {
+        // [quotas.weekly] priority = 99 — the BucketConfig common.priority
+        // flows through Config::component_config("quotas.weekly").
+        let cfg = QuotasConfig {
+            weekly: Some(BucketConfig {
+                common: crate::component::ComponentConfig {
+                    priority: 99,
+                    ..crate::component::ComponentConfig::default()
+                },
+                ..BucketConfig::default()
+            }),
+            ..QuotasConfig::default()
+        };
+        // Simulate the lookup path used by layout::resolve_cfg.
+        let bucket_common = cfg
+            .weekly
+            .as_ref()
+            .map(|b| b.common.clone())
+            .unwrap_or_default();
+        assert_eq!(bucket_common.priority, 99);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,6 +187,22 @@ impl Config {
             "burn" => self.burn.common.clone(),
             "agents" => pick(&self.agents),
             "quotas" => self.quotas.common.clone(),
+            n if crate::components::quotas_bucket_kind(n).is_some() => {
+                // Per-bucket layout knobs (priority/min/required/etc.) come
+                // from the `[quotas.<bucket>] common = ...` flattened fields
+                // when set; otherwise inherit the parent `[quotas]` common.
+                let bucket = crate::components::quotas_bucket_kind(n).unwrap();
+                let q = &self.quotas;
+                let bcfg = match bucket {
+                    crate::components::BucketKind::Hourly => &q.hourly,
+                    crate::components::BucketKind::Weekly => &q.weekly,
+                    crate::components::BucketKind::Design => &q.design,
+                    crate::components::BucketKind::Sonnet => &q.sonnet,
+                };
+                bcfg.as_ref()
+                    .map(|b| b.common.clone())
+                    .unwrap_or_else(|| q.common.clone())
+            }
             "ctx_bar" => self.ctx_bar.common.clone(),
             "loc" => pick(&self.loc),
             "model" => pick(&self.model),


### PR DESCRIPTION
## Summary

- Layout entries `quotas.hourly`, `quotas.weekly`, `quotas.design`, and `quotas.sonnet` now address a single quota bucket, letting users place buckets at distinct layout positions. Bare `quotas` keeps current behaviour.
- New `BucketKind` enum + `render_one_bucket` helper. `Quotas::render` becomes a loop over the helper, joined by the existing `·` separator.
- Dispatchers (`render_named`, `sizes_for`, `default_size_for`, `default_priority`, `Config::component_config`) all recognise `quotas.<bucket>`. Unknown sub-buckets like `quotas.foo` drop silently via the existing missing-component path.
- Per-bucket overrides upgraded from `Option<PctConfig>` to `Option<BucketConfig { pct, common }>` so `[quotas.hourly] priority = 30` (and `min` / `required` / `default` / `sizes`) flow through. Existing TOML stays backward-compatible — both `PctConfig` and `ComponentConfig` use `serde(flatten)`.
- Default priorities for the dotted entries: hourly 25 / weekly 20 / design 18 / sonnet 17 (above the bare-parent 15, since explicitly placed buckets are user-elevated).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test -- --test-threads=1` (57 passed)
- [x] `cargo run --bin gen_schema > config.schema.json` (committed)
- [x] New tests:
  - `quotas_hourly_only_renders_hourly_glyph`
  - `quotas_weekly_only_renders_weekly_glyph`
  - `quotas_unknown_bucket_drops_silently`
  - `quotas_bare_entry_still_renders_all_buckets`
  - `quotas_hourly_and_weekly_at_separate_positions`
  - `quotas_dotted_default_priorities`
  - `quotas_per_bucket_priority_override_via_bucket_common`

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)